### PR TITLE
Fix ordering of Gauss Hermite weights

### DIFF
--- a/src/FastGaussQuadrature.jl
+++ b/src/FastGaussQuadrature.jl
@@ -3,12 +3,14 @@ module FastGaussQuadrature
 
 export gausslegendre 
 export gausschebyshev 
+export gausshermite
 export gaussjacobi
 export gausslobatto
 export gaussradau
 
 include("gausslegendre.jl")
 include("gausschebyshev.jl")
+include("gausshermite.jl")
 include("gaussjacobi.jl")
 include("gausslobatto.jl")
 include("gaussradau.jl")

--- a/src/gausshermite.jl
+++ b/src/gausshermite.jl
@@ -23,13 +23,13 @@ else
 end
 
 if mod(n,2) == 1                              # fold out
-    w = [flipud(x[2]), x[2][2:end]]
+    w = [flipud(x[2][:]), x[2][2:end]]
     w = (sqrt(pi)/sum(w))*w
     x = ([-flipud(x[1]) ; x[1][2:end]], w)
 else
-    w = [fliplr(x[2]) x[2]] 
+    w = [flipud(x[2][:]), x[2][:]]
     w = (sqrt(pi)/sum(w))*w
-    x = ([-flipud(x[1]) ; x[1]], w[:])
+    x = ([-flipud(x[1]) ; x[1]], w)
 end
 
 end


### PR DESCRIPTION
Hi Alex,

This should fix the issues that would otherwise arise when:

```
using FastGaussQuadrature
f(x) = 1+x.^2;
for n in [0 1 20 200 201 202]
      x,w = gausshermite(n);
      println(dot(f(x),w))
end
```

Mikael
