### PR TITLE
Fix: inconsistent definition of weights in Gauss-Jacobi quadrature

### DIFF
--- a/src/FastGaussQuadrature.jl
+++ b/src/FastGaussQuadrature.jl
@@ -3,6 +3,7 @@ __precompile__()
 module FastGaussQuadrature
 
 using Compat, SpecialFunctions
+import GSL: sf_hyperg_2F1
 
 export gausslegendre
 export gausschebyshev

--- a/src/gaussjacobi.jl
+++ b/src/gaussjacobi.jl
@@ -380,6 +380,7 @@ function JacobiGW( n::Int64, a::Float64, b::Float64 )
     x, V = eig( TT )                       # Eigenvalue decomposition.
     # Quadrature weights:
     w = V[1,:].^2.*( 2^(ab+1)*gamma(a+1)*gamma(b+1)/gamma(2+ab) );
-    w .= w./sum(w);
+    c = sf_hyperg_2F1(1.0, -a, 2+b, -1.0)/(1+b) + sf_hyperg_2F1(1.0, -b, 2+a, -1.0)/(1+a)
+    w .= w./sum(w) * c
     x, vec(w)
 end

--- a/test/test_gaussjacobi.jl
+++ b/test/test_gaussjacobi.jl
@@ -56,7 +56,7 @@ x, w = gaussjacobi(10013, .9, -.1)
 # test last alpha and beta parameters:
 x, w = gaussjacobi(100, 19., 21.)
 @test abs(x[87] - 0.832211446176040) < tol
-@test abs(w[50] - 0.064530500882703) < tol
+@test abs(w[50] - 0.026363584978877) < tol
 
 # test for small alpha and beta:
 x, w = gaussjacobi(10000, .1, .2)


### PR DESCRIPTION
The definition of weights in gaussjacobi.jl is not consistent:

- For JacobiGW, sum(w) ==1.0
- For other cases, sum(w)==$\int (1-x)^a (1+x)^b dx$

This could be fixed through multiplication of a factor using hypergeometric function from GSL.jl. A simple approximate function of the factor might be better to avoid new dependence.