### PR TITLE
Faster compilation time

### DIFF
--- a/docs/src/gaussquadrature.md
+++ b/docs/src/gaussquadrature.md
@@ -62,7 +62,7 @@ Gauss quadrature for the weight functions ``w(x) = (1-x)^\alpha(1+x)^\beta``, ``
 
 * For ``n ≤ 100``: Use Newton's method to solve ``P_n(x)=0``. Evaluate ``P_n`` and ``P_n'`` by three-term recurrence.
 * For ``n > 100``: Use Newton's method to solve ``P_n(x)=0``. Evaluate ``P_n`` and ``P_n'`` by an asymptotic expansion (in the interior of ``[-1,1]``) and the three-term recurrence ``O(n^{-2})`` close to the endpoints. (This is a small modification to the algorithm described in [[3]](http://epubs.siam.org/doi/abs/10.1137/120889873).)
-* For ``max(a,b) > 5``: Use the Golub-Welsch algorithm requiring ``O(n^2)`` operations.
+* For ``\max(a,b) > 5``: Use the Golub-Welsch algorithm requiring ``O(n^2)`` operations.
 
 ```@docs
 gaussjacobi(n::Integer, α::Real, β::Real)

--- a/src/besselroots.jl
+++ b/src/besselroots.jl
@@ -184,7 +184,7 @@ function besselJ1(m)
          151 / 80, -7 / 24, 0.0, 2.0)
     # First 10 are precomputed:
     @inbounds for jj = 1:min(m, 10)
-        Jk2[jj] = BESSELJ1_ON_BESSELBESSELJ0_ROOTS[jj]
+        Jk2[jj] = BESSELJ1_ON_BESSELJ0_ROOTS[jj]
     end
     @inbounds for jj = 11:min(m, 15)
         ak = π * (jj - .25)

--- a/src/besselroots.jl
+++ b/src/besselroots.jl
@@ -45,13 +45,13 @@ function approx_besselroots(ν::Float64, n::Integer)
     x = zeros(n)
     if ν == 0
         for k in 1:min(n,20)
-            x[k] = J0_roots[k]
+            x[k] = BESSELJ0_ROOTS[k]
         end
         for k in min(n,20)+1:n
             x[k] = McMahon(ν, k)
         end
     elseif -1 ≤ ν ≤ 5
-        correctFirstFew = Piessens(ν)
+        correctFirstFew = piessens(ν)
         for k in 1:min(n,6)
             x[k] = correctFirstFew[k]
         end
@@ -131,10 +131,10 @@ function _piessens_chebyshev30(ν::Float64)
     return T
 end
 
-function Piessens(ν::Float64)
+function piessens(ν::Float64)
     # Piessens's Chebyshev series approximations (1984). Calculates the 6 first
     # zeros to at least 12 decimal figures in region -1 ≤ ν ≤ 5:
-    C = Piessens_C
+    C = PIESSENS_C
     T = _piessens_chebyshev30(ν)
     y = C'*T
     _y = collect(y)
@@ -151,7 +151,7 @@ function besselZeroRoots(m)
          0.0, -124 / 3, 0.0, 1.0, 0.0)
     # First 20 are precomputed:
     @inbounds for jj = 1:min(m, 20)
-        jk[jj] = J0_roots[jj]
+        jk[jj] = BESSELJ0_ROOTS[jj]
     end
     @inbounds for jj = 21:min(m, 47)
         ak = π * (jj - .25)
@@ -184,7 +184,7 @@ function besselJ1(m)
          151 / 80, -7 / 24, 0.0, 2.0)
     # First 10 are precomputed:
     @inbounds for jj = 1:min(m, 10)
-        Jk2[jj] = besselJ1_10[jj]
+        Jk2[jj] = BESSELJ1_ON_BESSELBESSELJ0_ROOTS[jj]
     end
     @inbounds for jj = 11:min(m, 15)
         ak = π * (jj - .25)

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,6 +1,13 @@
 @doc raw"""
 First twenty roots of Bessel funcion ``J_0`` in Float64.
 https://mathworld.wolfram.com/BesselFunctionZeros.html
+
+# Examples
+```jldoctest
+julia> zeros = besselj0.(FastGaussQuadrature.J0_roots);
+
+julia> all(zeros .< 1e-14)
+true
 """
 const J0_roots = @SVector [
     2.4048255576957728,
@@ -94,6 +101,15 @@ const besselJ1_10 = @SVector [
 
 @doc raw"""
 The first 11 roots of the Airy function in Float64 precision
+https://mathworld.wolfram.com/AiryFunctionZeros.html
+
+# Examples
+```jldoctest
+julia> zeros = airy.(FastGaussQuadrature.airy_roots);
+
+julia> all(zeros .< 1e-14)
+true
+```
 """
 const airy_roots = @SVector [
     -2.338107410459767,
@@ -101,7 +117,7 @@ const airy_roots = @SVector [
     -5.520559828095551,
     -6.786708090071759,
     -7.944133587120853,
-    -9.02265085340981,
+    -9.022650853340981,
     -10.04017434155809,
     -11.00852430373326,
     -11.93601556323626,

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -81,11 +81,11 @@ Values of Bessel function ``J_1`` on first ten roots of Bessel function `J_0`.
 ```jldoctest
 julia> roots = approx_besselroots(0,10);
 
-julia> (besselj1.(roots)).^2 ≈ FastGaussQuadrature.BESSELJ1_ON_BESSELBESSELJ0_ROOTS
+julia> (besselj1.(roots)).^2 ≈ FastGaussQuadrature.BESSELJ1_ON_BESSELJ0_ROOTS
 true
 ```
 """
-const BESSELJ1_ON_BESSELBESSELJ0_ROOTS = @SVector [
+const BESSELJ1_ON_BESSELJ0_ROOTS = @SVector [
     0.2695141239419169,
     0.1157801385822037,
     0.07368635113640822,

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -4,12 +4,12 @@ https://mathworld.wolfram.com/BesselFunctionZeros.html
 
 # Examples
 ```jldoctest
-julia> zeros = besselj0.(FastGaussQuadrature.J0_roots);
+julia> zeros = besselj0.(FastGaussQuadrature.BESSELJ0_ROOTS);
 
 julia> all(zeros .< 1e-14)
 true
 """
-const J0_roots = @SVector [
+const BESSELJ0_ROOTS = @SVector [
     2.4048255576957728,
     5.5200781102863106,
     8.6537279129110122,
@@ -40,7 +40,7 @@ j_{\nu, s} \approx \sum_{k}^{n} C_{k,s} T_k(\frac{\nu-2}{3})
 ```
 where $j_{\nu, s}$ is a ``s``-th zero of Bessel function ``J_\nu``, ``\{T_k\}`` are Chebyshev polynomials and ``C_{k, s}`` is the coefficients.
 """
-const Piessens_C = @SMatrix [
+const PIESSENS_C = @SMatrix [
        2.883975316228  8.263194332307 11.493871452173 14.689036505931 17.866882871378 21.034784308088
        0.767665211539  4.209200330779  4.317988625384  4.387437455306  4.435717974422  4.471319438161
       -0.086538804759 -0.164644722483 -0.130667664397 -0.109469595763 -0.094492317231 -0.083234240394
@@ -81,11 +81,11 @@ Values of Bessel function ``J_1`` on first ten roots of Bessel function `J_0`.
 ```jldoctest
 julia> roots = approx_besselroots(0,10);
 
-julia> (besselj1.(roots)).^2 ≈ FastGaussQuadrature.besselJ1_10
+julia> (besselj1.(roots)).^2 ≈ FastGaussQuadrature.BESSELJ1_ON_BESSELBESSELJ0_ROOTS
 true
 ```
 """
-const besselJ1_10 = @SVector [
+const BESSELJ1_ON_BESSELBESSELJ0_ROOTS = @SVector [
     0.2695141239419169,
     0.1157801385822037,
     0.07368635113640822,
@@ -105,13 +105,13 @@ https://mathworld.wolfram.com/AiryFunctionZeros.html
 
 # Examples
 ```jldoctest
-julia> zeros = airy.(FastGaussQuadrature.airy_roots);
+julia> zeros = airy.(FastGaussQuadrature.AIRY_ROOTS);
 
 julia> all(zeros .< 1e-14)
 true
 ```
 """
-const airy_roots = @SVector [
+const AIRY_ROOTS = @SVector [
     -2.338107410459767,
     -4.08794944413097,
     -5.520559828095551,

--- a/src/gausshermite.jl
+++ b/src/gausshermite.jl
@@ -24,6 +24,7 @@ function gausshermite(n::Integer)
     w .*= exp.(-x.^2)
     x, w
 end
+
 function unweightedgausshermite(n::Integer)
     # GAUSSHERMITE(n) COMPUTE THE GAUSS-HERMITE NODES AND WEIGHTS IN O(n) time.
     if n < 0
@@ -34,13 +35,13 @@ function unweightedgausshermite(n::Integer)
         return [0.0],[sqrt(π)]
     elseif n ≤ 20
        # GW algorithm
-       x = hermpts_gw(n)
+       x = hermite_gw(n)
     elseif n ≤ 200
        # REC algorithm
-       x = hermpts_rec(n)
+       x = hermite_rec(n)
     else
        # ASY algorithm
-       x = hermpts_asy(n)
+       x = hermite_asy(n)
     end
 
     # fold out
@@ -56,15 +57,15 @@ function unweightedgausshermite(n::Integer)
     return _x, _w
 end
 
-function hermpts_asy(n::Integer)
+function hermite_asy(n::Integer)
     # Compute Hermite nodes and weights using asymptotic formula
 
-    x0 = HermiteInitialGuesses(n)  # get initial guesses
+    x0 = hermite_initialguess(n)  # get initial guesses
     t0 = x0./sqrt(2n+1)
     θ = acos.(t0)  # convert to θ-variable
-    val = x0;
+    val = x0
     for _ in 1:20
-        val = hermpoly_asy_airy(n, θ);
+        val = hermpoly_asy_airy(n, θ)
         dθ = -val[1]./(sqrt(2).*sqrt(2n+1).*val[2].*sin.(θ))
         θ .-= dθ  # Newton update
         if norm(dθ,Inf) < sqrt(eps(Float64))/10
@@ -79,10 +80,10 @@ function hermpts_asy(n::Integer)
     return x, w
 end
 
-function hermpts_rec(n::Integer)
+function hermite_rec(n::Integer)
     # Compute Hermite nodes and weights using recurrence relation.
 
-    x0 = HermiteInitialGuesses(n)
+    x0 = hermite_initialguess(n)
     x0 .*= sqrt(2)
     val = x0
     for _ in 1:10
@@ -133,7 +134,7 @@ function hermpoly_rec(r::Base.OneTo, x0)
     n < 0 && throw(DomainError(n, "Input n must be a non-negative integer"))
     n == 0 && return [exp(-x0^2 / 4)]
     p = max(1,floor(Int,x0^2/100))
-    w = exp(-x0^2 / (4*p))
+    w = exp(-x0^2 / 4p)
     wc = 0 # 0 times we've applied wc
     ret = Vector{Float64}()
     Hold = one(x0)
@@ -158,12 +159,10 @@ end
 
 hermpoly_rec(r::AbstractRange, x0) = hermpoly_rec(Base.OneTo(maximum(r)), x0)[r.+1]
 
-
 function hermpoly_asy_airy(n::Integer, θ::AbstractVector)
-    # HERMPOLY_ASY evaluation hermite poly using Airy asymptotic formula in
-    # θ-space.
+    # HERMPOLY_ASY evaluation hermite poly using Airy asymptotic formula in θ-space.
 
-    musq = 2n+1;
+    musq = 2n+1
     cosT = cos.(θ)
     sinT = sin.(θ)
     sin2T = 2 .* cosT.*sinT
@@ -185,40 +184,40 @@ function hermpoly_asy_airy(n::Integer, θ::AbstractVector)
     b3 = -19/17*a3
 
     # u polynomials in (12.10.9)
-    u0 = 1; u1 = (cosT.^3-6*cosT)/24
-    u2 = @. (-9*cosT^4 + 249*cosT^2 + 145)/1152
-    u3 = @. (-4042*cosT^9+18189*cosT^7-28287*cosT^5-151995*cosT^3-259290*cosT)/414720
+    u0 = 1
+    u1 = (cosT.^3-6*cosT)/24
+    u2 = (-9*cosT.^4 + 249*cosT.^2 .+ 145)/1152
+    u3 = (-4042*cosT.^9+18189*cosT.^7-28287*cosT.^5-151995*cosT.^3-259290*cosT)/414720
 
     # first term
     A0 = 1
     val = A0*Airy0
 
     # second term
-    B0 = @. -(a0*φ^6 * u1+a1*u0)/χ^2
+    B0 = -(a0*u1.*φ.^6 .+ a1*u0) ./ χ.^2
     val .+=  B0.*Airy1./musq.^(4/3)
 
     # third term
-    A1 = @. (b0*φ^12 * u2 + b1*φ^6 * u1 + b2*u0)/χ^3
+    A1 = (b0*u2.*φ.^12 + b1*u1.*φ.^6 .+ b2*u0) ./ χ.^3
     val .+= A1.*Airy0/musq.^2
 
     # fourth term
-    B1 = @. -(φ^18 * u3 + a1*φ^12 * u2 + a2*φ^6 * u1 + a3*u0)/χ^5
+    B1 = -(u3.*φ.^18 + a1*u2.*φ.^12 + a2*u1.*φ.^6 .+ a3*u0) ./ χ.^5
     val .+= B1.*Airy1./musq.^(4/3+2)
 
     val .= C.*val
 
     ## Derivative
-
     η = .5*θ - .25*sin2T
     χ = -(3*η/2).^(2/3)
     φ = (-χ./sinT.^2).^(1/4)
     C = sqrt(2*π)*musq^(1/3)./φ
 
     # v polynomials in (12.10.10)
-    v0 = 1;
-    v1 = @. (cosT^3+6*cosT)/24
-    v2 = @. (15*cosT^4-327*cosT^2-143)/1152
-    v3 = @. (259290*cosT + 238425*cosT^3 - 36387*cosT^5 + 18189*cosT^7 - 4042*cosT^9)/414720
+    v0 = 1
+    v1 = (cosT.^3+6cosT)/24
+    v2 = (15*cosT.^4 - 327*cosT.^2 .- 143)/1152
+    v3 = (259290*cosT + 238425*cosT.^3 - 36387*cosT.^5 + 18189*cosT.^7 - 4042*cosT.^9)/414720
 
     # first term
     C0 = -(b0*φ.^6 .* v1 .+ b1.*v0)./χ
@@ -229,11 +228,11 @@ function hermpoly_asy_airy(n::Integer, θ::AbstractVector)
     dval = dval + D0*Airy1
 
     # third term
-    C1 = @. -(φ^18 * v3 + b1*φ^12 * v2 + b2*φ^6 * v1 + b3*v0)/χ^4
+    C1 = -(v3.*φ.^18 + b1*v2.*φ.^12 + b2*v1.*φ.^6 .+ b3*v0) ./ χ.^4
     dval = dval + C1.*Airy0/musq.^(2/3+2)
 
     # fourth term
-    D1 = @. (a0*φ^12 * v2 + a1*φ^6 * v1 + a2*v0)/χ^3
+    D1 = (a0*v2.*φ.^12 + a1*v1.*φ.^6 .+ a2*v0) ./ χ.^3
     dval = dval + D1.*Airy1/musq.^2
 
     dval = C.*dval
@@ -241,101 +240,86 @@ function hermpoly_asy_airy(n::Integer, θ::AbstractVector)
     return val, dval
 end
 
-let T(t) = @. t^(2/3)*(1+5/48*t^(-2)-5/36*t^(-4)+(77125/82944)*t^(-6) -108056875/6967296*t^(-8)+162375596875/334430208*t^(-10))
-    global function HermiteInitialGuesses(n::Integer)
-        #HERMITEINTITIALGUESSES(N), Initial guesses for Hermite zeros.
-        #
-        # [1] L. Gatteschi, Asymptotics and bounds for the zeros of Laguerre
-        # polynomials: a survey, J. Comput. Appl. Math., 144 (2002), pp. 7-27.
-        #
-        # [2] F. G. Tricomi, Sugli zeri delle funzioni di cui si conosce una
-        # rappresentazione asintotica, Ann. Mat. Pura Appl. 26 (1947), pp. 283-300.
+function hermite_initialguess(n::Integer)
+    # HERMITEINTITIALGUESSES(N), Initial guesses for Hermite zeros.
+    #
+    # [1] L. Gatteschi, Asymptotics and bounds for the zeros of Laguerre
+    # polynomials: a survey, J. Comput. Appl. Math., 144 (2002), pp. 7-27.
+    #
+    # [2] F. G. Tricomi, Sugli zeri delle funzioni di cui si conosce una
+    # rappresentazione asintotica, Ann. Mat. Pura Appl. 26 (1947), pp. 283-300.
 
-        # Error if n < 20 because initial guesses are based on asymptotic expansions:
-        @assert n ≥ 20
+    # Error if n < 20 because initial guesses are based on asymptotic expansions:
+    @assert n ≥ 20
 
-        # Gatteschi formula involving airy roots [1].
-        # These initial guess are good near x = sqrt(n+1/2);
-        if isodd(n)
-            m = (n-1)>>1
-            bess = (1:m)*π
-            a = .5
-        else
-            m = n>>1
-            bess = ((0:m-1) .+ 0.5)*π
-            a = -.5
-        end
-        ν = 4m + 2a + 2
-
-        airyrts = -T(3/8*π*(4*(1:m) .- 1))
-
-        # Roots of Airy function in Float64
-        # https://mathworld.wolfram.com/AiryFunctionZeros.html
-        airyrts_exact = [-2.338107410459762
-            -4.087949444130970
-            -5.520559828095555
-            -6.786708090071765
-            -7.944133587120863
-            -9.022650853340979
-            -10.040174341558084
-            -11.008524303733260
-            -11.936015563236262
-            -12.828776752865757]
-        airyrts[1:10] = airyrts_exact  # correct first 10.
-
-        x_init = sqrt.(abs.(ν .+ (2^(2/3)).*airyrts.*ν^(1/3) .+ (1/5*2^(4/3)).*airyrts.^2 .* ν^(-1/3) .+
-            (11/35-a^2-12/175).*airyrts.^3 ./ ν .+ ((16/1575).*airyrts.+(92/7875).*airyrts.^4).*2^(2/3).*ν^(-5/3) .-
-            ((15152/3031875).*airyrts.^5 .+ (1088/121275).*airyrts.^2).*2^(1/3).*ν^(-7/3)))
-        x_init_airy = reverse(x_init)
-
-        # Tricomi initial guesses. Equation (2.1) in [1]. Originally in [2].
-        # These initial guesses are good near x = 0 . Note: zeros of besselj(+/-.5,x)
-        # are integer and half-integer multiples of π.
-        # x_init_bess =  bess/sqrt(ν).*sqrt((1+ (bess.^2+2*(a^2-1))/3/ν^2) );
-        Tnk0 = fill(π/2,m)
-        ν = (4*m+2*a+2)
-        rhs = ((4*m+3) .- 4*(1:m))/ν*π
-
-        for k = 1:7
-            val = Tnk0 .- sin.(Tnk0) .- rhs
-            dval = 1 .- cos.(Tnk0)
-            dTnk0 = val./dval
-            Tnk0 = Tnk0 .- dTnk0
-        end
-
-        tnk = cos.(Tnk0./2).^2
-        x_init_sin = @. sqrt(ν*tnk - (5 / (4 * (1-tnk)^2) - 1 / (1 - tnk)-1 + 3*a^2)/3 / ν)
-
-        # Patch together
-        p = 0.4985+eps(Float64)
-        x_init = [x_init_sin[1:convert(Int,floor(p*n))] ;
-        x_init_airy[convert(Int,ceil(p*n)):end]]
-
-        if isodd(n)
-            x_init = [0 ; x_init]
-            x_init = x_init[1:m+1]
-        else
-            x_init = x_init[1:m]
-        end
-
-        return x_init
+    # Gatteschi formula involving airy roots [1].
+    # These initial guess are good near x = sqrt(n+1/2);
+    if isodd(n)
+        m = (n-1)>>1
+        # bess = (1:m)*π
+        a = .5
+    else
+        m = n>>1
+        # bess = ((0:m-1) .+ 0.5)*π
+        a = -.5
     end
+    ν = 4m + 2a + 2
+
+    T(t) = t^(2/3)*(1+5/48*t^(-2)-5/36*t^(-4)+(77125/82944)*t^(-6) -108056875/6967296*t^(-8)+162375596875/334430208*t^(-10))
+    airyrts = -T.(3π/8*(4*(1:m) .- 1))
+
+    airyrts[1:11] = airy_roots  # correct first 11.
+
+    x_init = sqrt.(abs.(ν .+ (2^(2/3)).*airyrts.*ν^(1/3) .+ (1/5*2^(4/3)).*airyrts.^2 .* ν^(-1/3) .+
+        (11/35-a^2-12/175).*airyrts.^3 ./ ν .+ ((16/1575).*airyrts.+(92/7875).*airyrts.^4).*2^(2/3).*ν^(-5/3) .-
+        ((15152/3031875).*airyrts.^5 .+ (1088/121275).*airyrts.^2).*2^(1/3).*ν^(-7/3)))
+    x_init_airy = reverse(x_init)
+
+    # Tricomi initial guesses. Equation (2.1) in [1]. Originally in [2].
+    # These initial guesses are good near x = 0 . Note: zeros of besselj(+/-.5,x)
+    # are integer and half-integer multiples of π.
+    # x_init_bess =  bess/sqrt(ν).*sqrt((1+ (bess.^2+2*(a^2-1))/3/ν^2) );
+    Tnk0 = fill(π/2,m)
+    rhs = ((4m+3) .- 4*(1:m))/ν*π
+
+    for k = 1:7
+        val = Tnk0 .- sin.(Tnk0) .- rhs
+        dval = 1 .- cos.(Tnk0)
+        dTnk0 = val./dval
+        Tnk0 = Tnk0 .- dTnk0
+    end
+
+    tnk = cos.(Tnk0/2).^2
+    x_init_sin = sqrt.(ν*tnk - ((tnk.+1/4)./(tnk.-1).^2 .+ (3a^2-1))/3ν)
+
+    # Patch together
+    p = 0.4985+eps(Float64)
+    x_init = [x_init_sin[1:convert(Int,floor(p*n))]
+    x_init_airy[convert(Int,ceil(p*n)):end]]
+
+    if isodd(n)
+        x_init = [0 ; x_init]
+        x_init = x_init[1:m+1]
+    else
+        x_init = x_init[1:m]
+    end
+
+    return x_init
 end
 
-
-function hermpts_gw(n::Integer)
+function hermite_gw(n::Integer)
     # Golub--Welsch algorithm. Used here for n ≤ 20.
 
     beta = sqrt.((1:n-1)/2)  # 3-term recurrence coeffs
     T = SymTridiagonal(zeros(n), beta)  # Jacobi matrix
-    (D, V) = eigen(T)  # Eigenvalue decomposition
-    indx = sortperm(D)  # Hermite points
-    x = D[indx]  # nodes
-    w = sqrt(π)*V[1,indx].^2  # weights
+    D, V = eigen(T)  # Eigenvalue decomposition
+    ind = sortperm(D)  # Hermite points
+    x = D[ind]  # nodes
+    w = sqrt(π)*V[1,ind].^2  # weights
 
     # Enforce symmetry:
-    ii = floor(Int, n/2)+1:n
-    x = x[ii]
-    w = w[ii]
-    return (x,exp.(x.^2).*w)
+    i = floor(Int, n/2)+1:n
+    x = x[i]
+    w = w[i]
+    return x, exp.(x.^2).*w
 end

--- a/src/gausshermite.jl
+++ b/src/gausshermite.jl
@@ -268,7 +268,7 @@ function hermite_initialguess(n::Integer)
     T(t) = t^(2/3)*(1+5/48*t^(-2)-5/36*t^(-4)+(77125/82944)*t^(-6) -108056875/6967296*t^(-8)+162375596875/334430208*t^(-10))
     airyrts = -T.(3π/8*(4*(1:m) .- 1))
 
-    airyrts[1:11] = airy_roots  # correct first 11.
+    airyrts[1:11] = AIRY_ROOTS  # correct first 11.
 
     x_init = sqrt.(abs.(ν .+ (2^(2/3)).*airyrts.*ν^(1/3) .+ (1/5*2^(4/3)).*airyrts.^2 .* ν^(-1/3) .+
         (11/35-a^2-12/175).*airyrts.^3 ./ ν .+ ((16/1575).*airyrts.+(92/7875).*airyrts.^4).*2^(2/3).*ν^(-5/3) .-

--- a/src/gaussjacobi.jl
+++ b/src/gaussjacobi.jl
@@ -278,29 +278,25 @@ function feval_asy1(n::Integer, α::Float64, β::Float64, t::AbstractVector, idx
     sinT = hcat(ones(N), cumprod(repeat((csc.(t/2)/2),1,M-1), dims=2))  # M × N matrix
     secT = sec.(t/2)/2
 
-    j = 0:M-2
-    _vec = @. (0.5+α+j)*(0.5-α+j)/(j+1)/(2n+α+β+j+2)
+    _vec = [(α+j-1/2)*(-α+j-1/2)/(2n+α+β+j+1)/j for j in 1:M-1]
     P1 = [1;cumprod(_vec)]
     P1[3:4:end] = -P1[3:4:end]
     P1[4:4:end] = -P1[4:4:end]
     P2 = Matrix(1.0I, M, M)
-    for l in 0:M-1
-        j = 0:M-l-2
-        _vec = @. (0.5+β+j)*(0.5-β+j)/(j+1)/(2n+α+β+j+l+2)
-        P2[l+1,(l+1).+(1:length(j))] = cumprod(_vec)
+    for l in 1:M
+        _vec = [(β+j-1/2)*(-β+j-1/2)/(2n+α+β+j+l)/j for j in 1:M-l-2]
+        P2[l,l+1:M-2] = cumprod(_vec)
     end
     PHI = repeat(P1,1,M).*P2
 
-    j = 0:M-2
-    _vec = @. (0.5+α+j)*(0.5-α+j)/(j+1)/(2*(n-1)+α+β+j+2)
+    _vec = [(α+j-1/2)*(-α+j-1/2)/(2n+α+β+j-1)/j for j in 1:M-1]
     P1 = [1;cumprod(_vec)]
     P1[3:4:end] = -P1[3:4:end]
     P1[4:4:end] = -P1[4:4:end]
     P2 = Matrix(1.0I, M, M)
-    for l in 0:M-1
-        j = 0:M-l-2
-        _vec = @. (0.5+β+j)*(0.5-β+j)/(j+1)/(2*(n-1)+α+β+j+l+2)
-        P2[l+1,(l+1).+(1:length(j))] = cumprod(_vec)
+    for l in 1:M
+        _vec = [(β+j-1/2)*(-β+j-1/2)/(2n+α+β+j+l-2)/j for j in 1:M-l-2]
+        P2[l,l+1:M-2] = cumprod(_vec)
     end
     PHI2 = repeat(P1,1,M).*P2
 
@@ -352,7 +348,7 @@ function feval_asy1(n::Integer, α::Float64, β::Float64, t::AbstractVector, idx
     g = [1, 1/12, 1/288, -139/51840, -571/2488320, 163879/209018880,
          5246819/75246796800, -534703531/902961561600,
          -4483131259/86684309913600, 432261921612371/514904800886784000]
-    f(g,z) = sum(g.*[1;cumprod(ones(9)./z)])
+    f(g,z) = dot(g, [1;cumprod(ones(9)./z)])
 
     # Float constant C, C2
     C = 2*p2*(f(g,n+α)*f(g,n+β)/f(g,2n+α+β))/π
@@ -394,11 +390,11 @@ function boundary(n::Integer, α::Float64, β::Float64, npts::Integer)
     x += dx
 
     # flip:
-    x = x[npts:-1:1]
-    ders = ders[npts:-1:1]
+    x = reverse(x)
+    ders = reverse(ders)
 
     # Revert to x-space:
-    w = @. 1 /((1-x^2)*ders^2)
+    w = 1 ./ ((1 .- x.^2) .* ders.^2)
     return x, w
 end
 

--- a/src/gausslaguerre.jl
+++ b/src/gausslaguerre.jl
@@ -534,7 +534,7 @@ end
 function compute_airy_root(n, k)
     index = n-k+1
     if index ≤ 11
-        ak = airy_roots[index]
+        ak = AIRY_ROOTS[index]
     else
         t = 3 * π/2 * (index-0.25)
         ak = -t^(2/3)*(1 + 5/48/t^2 - 5/36/t^4 + 77125/82944/t^6 -10856875/6967296/t^8)


### PR DESCRIPTION

## Faster Compilation Time (`gaussjacobi` and `gausshermite`)
Removing `@.` macro makes faster and readable code.
related: #47 

```julia
t=time(); FastGaussQuadrature.jacobi_asy(101,1., 1.); time() - t
```

On current master (tried 3 times):
5.6319661140441895
5.672187805175781
5.6497509479522705

With this PR (tried 3 times):
5.377803087234497
5.1646201610565186
5.101907014846802

```julia
t=time(); gausshermite(101); time() - t
```

On current master (tried 3 times):
5.864084005355835
5.775697946548462
5.807419061660767

With this PR (tried 3 times):
4.963570833206177
4.937578916549683
4.9188759326934814

## Fix `AIRY_ROOTS`
Previously, there was two definitions of `airy_roots` in the code, and one of them is not correct.

* :ng: [-9.02265085340981](https://github.com/JuliaApproximation/FastGaussQuadrature.jl/blob/v0.4.2/src/gausslaguerre.jl#L60)
* :ok: [-9.022650853340979](https://github.com/JuliaApproximation/FastGaussQuadrature.jl/blob/v0.4.2/src/gausshermite.jl#L255)

I've fixed this.

## Other
* minor refactorings
* use CAPITAL_CASE for global constants
* fix typo in document
* add more doctests