### PR TITLE
Fix documentation

### DIFF
--- a/src/constants.jl
+++ b/src/constants.jl
@@ -8,6 +8,7 @@ julia> zeros = besselj0.(FastGaussQuadrature.BESSELJ0_ROOTS);
 
 julia> all(zeros .< 1e-14)
 true
+```
 """
 const BESSELJ0_ROOTS = @SVector [
     2.4048255576957728,

--- a/src/gausschebyshev.jl
+++ b/src/gausschebyshev.jl
@@ -49,7 +49,7 @@ true
 Return nodes and weights of [Gauss-Chebyshev quadrature](https://en.wikipedia.org/wiki/Chebyshev%E2%80%93Gauss_quadrature) of the 3rd kind.
 
 ```math
-\int_{-1}^{1} f(x)\sqrt{1-x^2} dx \approx \sum_{i=1}^{n} w_i f(x_i)
+\int_{-1}^{1} f(x)\sqrt{\frac{1+x}{1-x}} dx \approx \sum_{i=1}^{n} w_i f(x_i)
 ```
 
 # Examples
@@ -71,7 +71,7 @@ true
 Return nodes and weights of [Gauss-Chebyshev quadrature](https://en.wikipedia.org/wiki/Chebyshev%E2%80%93Gauss_quadrature) of the 4th kind.
 
 ```math
-\int_{-1}^{1} f(x)\sqrt{1-x^2} dx \approx \sum_{i=1}^{n} w_i f(x_i)
+\int_{-1}^{1} f(x)\sqrt{\frac{1-x}{1+x}} dx \approx \sum_{i=1}^{n} w_i f(x_i)
 ```
 
 # Examples


### PR DESCRIPTION
This PR fixes #108 and `jldoctest` for [`FastGaussQuadrature.BESSELJ0_ROOTS`](https://juliaapproximation.github.io/FastGaussQuadrature.jl/v0.4.9/misc/#FastGaussQuadrature.BESSELJ0_ROOTS).

![image](https://user-images.githubusercontent.com/7488140/155878875-bb8d0d7c-2bc1-46cb-b3a7-4f7ccd46f6cc.png)
