### PR TITLE
correct gaussjacobi docstring

### DIFF
--- a/docs/src/gaussquadrature.md
+++ b/docs/src/gaussquadrature.md
@@ -62,7 +62,7 @@ Gauss quadrature for the weight functions ``w(x) = (1-x)^\alpha(1+x)^\beta``, ``
 
 * For ``n ≤ 100``: Use Newton's method to solve ``P_n(x)=0``. Evaluate ``P_n`` and ``P_n'`` by three-term recurrence.
 * For ``n > 100``: Use Newton's method to solve ``P_n(x)=0``. Evaluate ``P_n`` and ``P_n'`` by an asymptotic expansion (in the interior of ``[-1,1]``) and the three-term recurrence ``O(n^{-2})`` close to the endpoints. (This is a small modification to the algorithm described in [[3]](http://epubs.siam.org/doi/abs/10.1137/120889873).)
-* For ``\max(a,b) > 5``: Use the Golub-Welsch algorithm requiring ``O(n^2)`` operations.
+* For ``\max(\alpha,\beta) > 5``: Use the Golub-Welsch algorithm requiring ``O(n^2)`` operations.
 
 ```@docs
 gaussjacobi(n::Integer, α::Real, β::Real)

--- a/src/gaussjacobi.jl
+++ b/src/gaussjacobi.jl
@@ -1,7 +1,8 @@
 @doc raw"""
-    gaussjacobi(n::Integer) -> x, w  # nodes, weights
+    gaussjacobi(n::Integer, α::Real, β::Real) -> x, w  # nodes, weights
 
-Return nodes `x` and weights `w` of [Gauss-Jacobi quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Jacobi_quadrature).
+Return nodes `x` and weights `w` of [Gauss-Jacobi quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Jacobi_quadrature)
+for exponents `α` and `β`.
 
 ```math
 \int_{-1}^{1} f(x) (1-x)^\alpha(1+x)^\beta dx \approx \sum_{i=1}^{n} w_i f(x_i)


### PR DESCRIPTION
I noticed that the `gaussjacobi` docstring was missing the `α, β` arguments.