### PR TITLE
Deprecate `gausschebyshev` and add `gausschebyshevt`, ..., `gausschebyshevw`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FastGaussQuadrature"
 uuid = "442a2c76-b920-505d-bb47-c5924d526838"
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/docs/src/gaussquadrature.md
+++ b/docs/src/gaussquadrature.md
@@ -53,10 +53,10 @@ There are four kinds of Gauss-Chebyshev quadrature rules, corresponding to four 
 They are all have explicit simple formulas for the nodes and weights [[4]](https://books.google.co.jp/books?id=8FHf0P3to0UC).
 
 ```@docs
-gausschebyshev1(n::Integer)
-gausschebyshev2(n::Integer)
-gausschebyshev3(n::Integer)
-gausschebyshev4(n::Integer)
+gausschebyshevT(n::Integer)
+gausschebyshevU(n::Integer)
+gausschebyshevV(n::Integer)
+gausschebyshevW(n::Integer)
 ```
 
 

--- a/docs/src/gaussquadrature.md
+++ b/docs/src/gaussquadrature.md
@@ -53,7 +53,10 @@ There are four kinds of Gauss-Chebyshev quadrature rules, corresponding to four 
 They are all have explicit simple formulas for the nodes and weights [[4]](https://books.google.co.jp/books?id=8FHf0P3to0UC).
 
 ```@docs
-gausschebyshev(n::Integer, kind::Integer)
+gausschebyshev1(n::Integer)
+gausschebyshev2(n::Integer)
+gausschebyshev3(n::Integer)
+gausschebyshev4(n::Integer)
 ```
 
 

--- a/docs/src/gaussquadrature.md
+++ b/docs/src/gaussquadrature.md
@@ -53,10 +53,10 @@ There are four kinds of Gauss-Chebyshev quadrature rules, corresponding to four 
 They are all have explicit simple formulas for the nodes and weights [[4]](https://books.google.co.jp/books?id=8FHf0P3to0UC).
 
 ```@docs
-gausschebyshevT(n::Integer)
-gausschebyshevU(n::Integer)
-gausschebyshevV(n::Integer)
-gausschebyshevW(n::Integer)
+gausschebyshevt(n::Integer)
+gausschebyshevu(n::Integer)
+gausschebyshevv(n::Integer)
+gausschebyshevw(n::Integer)
 ```
 
 

--- a/src/FastGaussQuadrature.jl
+++ b/src/FastGaussQuadrature.jl
@@ -6,6 +6,10 @@ using StaticArrays
 
 export gausslegendre
 export gausschebyshev
+export gausschebyshev1
+export gausschebyshev2
+export gausschebyshev3
+export gausschebyshev4
 export gausslaguerre
 export gausshermite
 export gaussjacobi

--- a/src/FastGaussQuadrature.jl
+++ b/src/FastGaussQuadrature.jl
@@ -6,10 +6,10 @@ using StaticArrays
 
 export gausslegendre
 export gausschebyshev
-export gausschebyshev1
-export gausschebyshev2
-export gausschebyshev3
-export gausschebyshev4
+export gausschebyshevT
+export gausschebyshevU
+export gausschebyshevV
+export gausschebyshevW
 export gausslaguerre
 export gausshermite
 export gaussjacobi

--- a/src/FastGaussQuadrature.jl
+++ b/src/FastGaussQuadrature.jl
@@ -6,10 +6,10 @@ using StaticArrays
 
 export gausslegendre
 export gausschebyshev
-export gausschebyshevT
-export gausschebyshevU
-export gausschebyshevV
-export gausschebyshevW
+export gausschebyshevt
+export gausschebyshevu
+export gausschebyshevv
+export gausschebyshevw
 export gausslaguerre
 export gausshermite
 export gaussjacobi

--- a/src/gausschebyshev.jl
+++ b/src/gausschebyshev.jl
@@ -1,5 +1,5 @@
 @doc raw"""
-    gausschebyshevT(n::Integer) -> x, w  # nodes, weights
+    gausschebyshevt(n::Integer) -> x, w  # nodes, weights
 
 Return nodes `x` and weights `w` of [Gauss-Chebyshev quadrature](https://en.wikipedia.org/wiki/Chebyshev%E2%80%93Gauss_quadrature) of the 1st kind.
 
@@ -9,7 +9,7 @@ Return nodes `x` and weights `w` of [Gauss-Chebyshev quadrature](https://en.wiki
 
 # Examples
 ```jldoctest
-julia> x, w = gausschebyshevT(3);
+julia> x, w = gausschebyshevt(3);
 
 julia> f(x) = x^4;
 
@@ -19,7 +19,7 @@ julia> I ≈ 3π/8
 true
 ```
 """
-function gausschebyshevT(n::Integer)
+function gausschebyshevt(n::Integer)
     if n < 0
         throw(DomainError(n, "Input n must be a non-negative integer"))
     end
@@ -27,7 +27,7 @@ function gausschebyshevT(n::Integer)
 end
 
 @doc raw"""
-    gausschebyshevU(n::Integer) -> x, w  # nodes, weights
+    gausschebyshevu(n::Integer) -> x, w  # nodes, weights
 
 Return nodes `x` and weights `w` of [Gauss-Chebyshev quadrature](https://en.wikipedia.org/wiki/Chebyshev%E2%80%93Gauss_quadrature) of the 2nd kind.
 
@@ -37,7 +37,7 @@ Return nodes `x` and weights `w` of [Gauss-Chebyshev quadrature](https://en.wiki
 
 # Examples
 ```jldoctest
-julia> x, w = gausschebyshevU(3);
+julia> x, w = gausschebyshevu(3);
 
 julia> f(x) = x^4;
 
@@ -47,7 +47,7 @@ julia> I ≈ π/16
 true
 ```
 """
-function gausschebyshevU(n::Integer)
+function gausschebyshevu(n::Integer)
     if n < 0
         throw(DomainError(n, "Input n must be a non-negative integer"))
     end
@@ -55,7 +55,7 @@ function gausschebyshevU(n::Integer)
 end
 
 @doc raw"""
-    gausschebyshevV(n::Integer) -> x, w  # nodes, weights
+    gausschebyshevv(n::Integer) -> x, w  # nodes, weights
 
 Return nodes `x` and weights `w` of [Gauss-Chebyshev quadrature](https://en.wikipedia.org/wiki/Chebyshev%E2%80%93Gauss_quadrature) of the 3rd kind.
 
@@ -65,7 +65,7 @@ Return nodes `x` and weights `w` of [Gauss-Chebyshev quadrature](https://en.wiki
 
 # Examples
 ```jldoctest
-julia> x, w = gausschebyshevV(3);
+julia> x, w = gausschebyshevv(3);
 
 julia> f(x) = x^4;
 
@@ -75,7 +75,7 @@ julia> I ≈ 3π/8
 true
 ```
 """
-function gausschebyshevV(n::Integer)
+function gausschebyshevv(n::Integer)
     if n < 0
         throw(DomainError(n, "Input n must be a non-negative integer"))
     end
@@ -83,7 +83,7 @@ function gausschebyshevV(n::Integer)
 end
 
 @doc raw"""
-    gausschebyshevW(n::Integer) -> x, w  # nodes, weights
+    gausschebyshevw(n::Integer) -> x, w  # nodes, weights
 
 Return nodes `x` and weights `w` of [Gauss-Chebyshev quadrature](https://en.wikipedia.org/wiki/Chebyshev%E2%80%93Gauss_quadrature) of the 4th kind.
 
@@ -93,7 +93,7 @@ Return nodes `x` and weights `w` of [Gauss-Chebyshev quadrature](https://en.wiki
 
 # Examples
 ```jldoctest
-julia> x, w = gausschebyshevW(3);
+julia> x, w = gausschebyshevw(3);
 
 julia> f(x) = x^4;
 
@@ -103,7 +103,7 @@ julia> I ≈ 3π/8
 true
 ```
 """
-function gausschebyshevW(n::Integer)
+function gausschebyshevw(n::Integer)
     if n < 0
         throw(DomainError(n, "Input n must be a non-negative integer"))
     end
@@ -119,21 +119,21 @@ function gausschebyshev(n::Integer, kind::Integer=1)
 
     # Use known explicit formulas. Complexity O(n).
     if kind == 1
-        # Gauss-ChebyshevT quadrature, i.e., w(x) = 1/sqrt(1-x^2)
-        Base.depwarn("`gausschebyshev(n, 1)` is deprecated and will be removed in the next breaking release. Please use `gausschebyshevT(n)` instead.", :gausschebyshev)
-        return gausschebyshevT(n)
+        # Gauss-Chebyshevt quadrature, i.e., w(x) = 1/sqrt(1-x^2)
+        Base.depwarn("`gausschebyshev(n, 1)` is deprecated and will be removed in the next breaking release. Please use `gausschebyshevt(n)` instead.", :gausschebyshev)
+        return gausschebyshevt(n)
     elseif kind == 2
-        # Gauss-ChebyshevU quadrature, i.e., w(x) = sqrt(1-x^2)
-        Base.depwarn("`gausschebyshev(n, 2)` is deprecated and will be removed in the next breaking release. Please use `gausschebyshevU(n)` instead.", :gausschebyshev)
-        return gausschebyshevU(n)
+        # Gauss-Chebyshevu quadrature, i.e., w(x) = sqrt(1-x^2)
+        Base.depwarn("`gausschebyshev(n, 2)` is deprecated and will be removed in the next breaking release. Please use `gausschebyshevu(n)` instead.", :gausschebyshev)
+        return gausschebyshevu(n)
     elseif kind == 3
-        # Gauss-ChebyshevV quadrature, i.e., w(x) = sqrt((1+x)/(1-x))
-        Base.depwarn("`gausschebyshev(n, 3)` is deprecated and will be removed in the next breaking release. Please use `gausschebyshevV(n)` instead.", :gausschebyshev)
-        return gausschebyshevV(n)
+        # Gauss-Chebyshevv quadrature, i.e., w(x) = sqrt((1+x)/(1-x))
+        Base.depwarn("`gausschebyshev(n, 3)` is deprecated and will be removed in the next breaking release. Please use `gausschebyshevv(n)` instead.", :gausschebyshev)
+        return gausschebyshevv(n)
     elseif kind == 4
-        # Gauss-ChebyshevW quadrature, i.e., w(x) = sqrt((1-x)/(1+x))
-        Base.depwarn("`gausschebyshev(n, 4)` is deprecated and will be removed in the next breaking release. Please use `gausschebyshevW(n)` instead.", :gausschebyshev)
-        return gausschebyshevW(n)
+        # Gauss-Chebyshevw quadrature, i.e., w(x) = sqrt((1-x)/(1+x))
+        Base.depwarn("`gausschebyshev(n, 4)` is deprecated and will be removed in the next breaking release. Please use `gausschebyshevw(n)` instead.", :gausschebyshev)
+        return gausschebyshevw(n)
     else
         throw(ArgumentError("Chebyshev kind should be 1, 2, 3, or 4"))
     end

--- a/src/gausschebyshev.jl
+++ b/src/gausschebyshev.jl
@@ -1,5 +1,5 @@
 @doc raw"""
-    gausschebyshev1(n::Integer) -> x, w  # nodes, weights
+    gausschebyshevT(n::Integer) -> x, w  # nodes, weights
 
 Return nodes `x` and weights `w` of [Gauss-Chebyshev quadrature](https://en.wikipedia.org/wiki/Chebyshev%E2%80%93Gauss_quadrature) of the 1st kind.
 
@@ -9,7 +9,7 @@ Return nodes `x` and weights `w` of [Gauss-Chebyshev quadrature](https://en.wiki
 
 # Examples
 ```jldoctest
-julia> x, w = gausschebyshev1(3);
+julia> x, w = gausschebyshevT(3);
 
 julia> f(x) = x^4;
 
@@ -19,7 +19,7 @@ julia> I ≈ 3π/8
 true
 ```
 """
-function gausschebyshev1(n::Integer)
+function gausschebyshevT(n::Integer)
     if n < 0
         throw(DomainError(n, "Input n must be a non-negative integer"))
     end
@@ -27,7 +27,7 @@ function gausschebyshev1(n::Integer)
 end
 
 @doc raw"""
-    gausschebyshev2(n::Integer) -> x, w  # nodes, weights
+    gausschebyshevU(n::Integer) -> x, w  # nodes, weights
 
 Return nodes `x` and weights `w` of [Gauss-Chebyshev quadrature](https://en.wikipedia.org/wiki/Chebyshev%E2%80%93Gauss_quadrature) of the 2nd kind.
 
@@ -37,7 +37,7 @@ Return nodes `x` and weights `w` of [Gauss-Chebyshev quadrature](https://en.wiki
 
 # Examples
 ```jldoctest
-julia> x, w = gausschebyshev2(3);
+julia> x, w = gausschebyshevU(3);
 
 julia> f(x) = x^4;
 
@@ -47,7 +47,7 @@ julia> I ≈ π/16
 true
 ```
 """
-function gausschebyshev2(n::Integer)
+function gausschebyshevU(n::Integer)
     if n < 0
         throw(DomainError(n, "Input n must be a non-negative integer"))
     end
@@ -55,7 +55,7 @@ function gausschebyshev2(n::Integer)
 end
 
 @doc raw"""
-    gausschebyshev3(n::Integer) -> x, w  # nodes, weights
+    gausschebyshevV(n::Integer) -> x, w  # nodes, weights
 
 Return nodes `x` and weights `w` of [Gauss-Chebyshev quadrature](https://en.wikipedia.org/wiki/Chebyshev%E2%80%93Gauss_quadrature) of the 3rd kind.
 
@@ -65,7 +65,7 @@ Return nodes `x` and weights `w` of [Gauss-Chebyshev quadrature](https://en.wiki
 
 # Examples
 ```jldoctest
-julia> x, w = gausschebyshev3(3);
+julia> x, w = gausschebyshevV(3);
 
 julia> f(x) = x^4;
 
@@ -75,7 +75,7 @@ julia> I ≈ 3π/8
 true
 ```
 """
-function gausschebyshev3(n::Integer)
+function gausschebyshevV(n::Integer)
     if n < 0
         throw(DomainError(n, "Input n must be a non-negative integer"))
     end
@@ -83,7 +83,7 @@ function gausschebyshev3(n::Integer)
 end
 
 @doc raw"""
-    gausschebyshev4(n::Integer) -> x, w  # nodes, weights
+    gausschebyshevW(n::Integer) -> x, w  # nodes, weights
 
 Return nodes `x` and weights `w` of [Gauss-Chebyshev quadrature](https://en.wikipedia.org/wiki/Chebyshev%E2%80%93Gauss_quadrature) of the 4th kind.
 
@@ -93,7 +93,7 @@ Return nodes `x` and weights `w` of [Gauss-Chebyshev quadrature](https://en.wiki
 
 # Examples
 ```jldoctest
-julia> x, w = gausschebyshev4(3);
+julia> x, w = gausschebyshevW(3);
 
 julia> f(x) = x^4;
 
@@ -103,7 +103,7 @@ julia> I ≈ 3π/8
 true
 ```
 """
-function gausschebyshev4(n::Integer)
+function gausschebyshevW(n::Integer)
     if n < 0
         throw(DomainError(n, "Input n must be a non-negative integer"))
     end
@@ -120,20 +120,20 @@ function gausschebyshev(n::Integer, kind::Integer=1)
     # Use known explicit formulas. Complexity O(n).
     if kind == 1
         # Gauss-ChebyshevT quadrature, i.e., w(x) = 1/sqrt(1-x^2)
-        Base.depwarn("`gausschebyshev(n, 1)` is deprecated and will be removed in the next breaking release. Please use `gausschebyshev1(n)` instead.", :gausschebyshev)
-        return gausschebyshev1(n)
+        Base.depwarn("`gausschebyshev(n, 1)` is deprecated and will be removed in the next breaking release. Please use `gausschebyshevT(n)` instead.", :gausschebyshev)
+        return gausschebyshevT(n)
     elseif kind == 2
         # Gauss-ChebyshevU quadrature, i.e., w(x) = sqrt(1-x^2)
-        Base.depwarn("`gausschebyshev(n, 2)` is deprecated and will be removed in the next breaking release. Please use `gausschebyshev2(n)` instead.", :gausschebyshev)
-        return gausschebyshev2(n)
+        Base.depwarn("`gausschebyshev(n, 2)` is deprecated and will be removed in the next breaking release. Please use `gausschebyshevU(n)` instead.", :gausschebyshev)
+        return gausschebyshevU(n)
     elseif kind == 3
         # Gauss-ChebyshevV quadrature, i.e., w(x) = sqrt((1+x)/(1-x))
-        Base.depwarn("`gausschebyshev(n, 3)` is deprecated and will be removed in the next breaking release. Please use `gausschebyshev3(n)` instead.", :gausschebyshev)
-        return gausschebyshev3(n)
+        Base.depwarn("`gausschebyshev(n, 3)` is deprecated and will be removed in the next breaking release. Please use `gausschebyshevV(n)` instead.", :gausschebyshev)
+        return gausschebyshevV(n)
     elseif kind == 4
         # Gauss-ChebyshevW quadrature, i.e., w(x) = sqrt((1-x)/(1+x))
-        Base.depwarn("`gausschebyshev(n, 4)` is deprecated and will be removed in the next breaking release. Please use `gausschebyshev4(n)` instead.", :gausschebyshev)
-        return gausschebyshev4(n)
+        Base.depwarn("`gausschebyshev(n, 4)` is deprecated and will be removed in the next breaking release. Please use `gausschebyshevW(n)` instead.", :gausschebyshev)
+        return gausschebyshevW(n)
     else
         throw(ArgumentError("Chebyshev kind should be 1, 2, 3, or 4"))
     end

--- a/src/gausschebyshev.jl
+++ b/src/gausschebyshev.jl
@@ -9,7 +9,7 @@ Return nodes `x` and weights `w` of [Gauss-Chebyshev quadrature](https://en.wiki
 
 # Examples
 ```jldoctest
-julia> x, w = gausschebyshev(3);
+julia> x, w = gausschebyshev1(3);
 
 julia> f(x) = x^4;
 
@@ -37,7 +37,7 @@ Return nodes `x` and weights `w` of [Gauss-Chebyshev quadrature](https://en.wiki
 
 # Examples
 ```jldoctest
-julia> x, w = gausschebyshev(3, 2);
+julia> x, w = gausschebyshev2(3);
 
 julia> f(x) = x^4;
 
@@ -65,7 +65,7 @@ Return nodes `x` and weights `w` of [Gauss-Chebyshev quadrature](https://en.wiki
 
 # Examples
 ```jldoctest
-julia> x, w = gausschebyshev(3, 3);
+julia> x, w = gausschebyshev3(3);
 
 julia> f(x) = x^4;
 
@@ -93,7 +93,7 @@ Return nodes `x` and weights `w` of [Gauss-Chebyshev quadrature](https://en.wiki
 
 # Examples
 ```jldoctest
-julia> x, w = gausschebyshev(3, 4);
+julia> x, w = gausschebyshev4(3);
 
 julia> f(x) = x^4;
 

--- a/src/gausschebyshev.jl
+++ b/src/gausschebyshev.jl
@@ -1,6 +1,5 @@
 @doc raw"""
-    gausschebyshev(n::Integer) -> x, w  # nodes, weights
-    gausschebyshev(n::Integer, 1) -> x, w  # nodes, weights
+    gausschebyshev1(n::Integer) -> x, w  # nodes, weights
 
 Return nodes `x` and weights `w` of [Gauss-Chebyshev quadrature](https://en.wikipedia.org/wiki/Chebyshev%E2%80%93Gauss_quadrature) of the 1st kind.
 
@@ -19,10 +18,11 @@ julia> I = dot(w, f.(x));
 julia> I ≈ 3π/8
 true
 ```
+"""
+gausschebyshev1(n::Integer) = [cos((2 * k - 1) * π / (2 * n)) for k = n:-1:1], fill(π / n, n)
 
----
-
-    gausschebyshev(n::Integer, 2) -> x, w  # nodes, weights
+@doc raw"""
+    gausschebyshev2(n::Integer) -> x, w  # nodes, weights
 
 Return nodes `x` and weights `w` of [Gauss-Chebyshev quadrature](https://en.wikipedia.org/wiki/Chebyshev%E2%80%93Gauss_quadrature) of the 2nd kind.
 
@@ -41,10 +41,11 @@ julia> I = dot(w, f.(x));
 julia> I ≈ π/16
 true
 ```
+"""
+gausschebyshev2(n::Integer) = [cos(k * π / (n + 1)) for k = n:-1:1], [π/(n + 1) * sin(k / (n + 1) * π)^2 for k = n:-1:1]
 
----
-
-    gausschebyshev(n::Integer, 3) -> x, w  # nodes, weights
+@doc raw"""
+    gausschebyshev3(n::Integer) -> x, w  # nodes, weights
 
 Return nodes `x` and weights `w` of [Gauss-Chebyshev quadrature](https://en.wikipedia.org/wiki/Chebyshev%E2%80%93Gauss_quadrature) of the 3rd kind.
 
@@ -63,10 +64,11 @@ julia> I = dot(w, f.(x));
 julia> I ≈ 3π/8
 true
 ```
+"""
+gausschebyshev3(n::Integer) = [cos((k - .5) * π / (n + .5)) for k = n:-1:1], [2π / (n + .5) * cos((k - .5) * π / (2 * (n + .5)))^2 for k = n:-1:1]
 
----
-
-    gausschebyshev(n::Integer, 4) -> x, w  # nodes, weights
+@doc raw"""
+    gausschebyshev4(n::Integer) -> x, w  # nodes, weights
 
 Return nodes `x` and weights `w` of [Gauss-Chebyshev quadrature](https://en.wikipedia.org/wiki/Chebyshev%E2%80%93Gauss_quadrature) of the 4th kind.
 
@@ -86,6 +88,8 @@ julia> I ≈ 3π/8
 true
 ```
 """
+gausschebyshev4(n::Integer) = [cos(k * π / (n + .5)) for k = n:-1:1], [2π / (n + .5) * sin(k * π / (2 * (n + .5)))^2 for k = n:-1:1]
+
 function gausschebyshev(n::Integer, kind::Integer=1)
     # GAUSS-CHEBYSHEV NODES AND WEIGHTS.
 
@@ -96,19 +100,20 @@ function gausschebyshev(n::Integer, kind::Integer=1)
     # Use known explicit formulas. Complexity O(n).
     if kind == 1
         # Gauss-ChebyshevT quadrature, i.e., w(x) = 1/sqrt(1-x^2)
-        return ([cos((2 * k - 1) * π / (2 * n)) for k = n:-1:1], fill(π / n, n))
+        Base.depwarn("`gausschebyshev(n, 1)` is deprecated and will be removed in the next breaking release. Please use `gausschebyshev1(n)` instead.", :gausschebyshev)
+        return gausschebyshev1(n)
     elseif kind == 2
         # Gauss-ChebyshevU quadrature, i.e., w(x) = sqrt(1-x^2)
-        return ([cos(k * π / (n + 1)) for k = n:-1:1],
-                [π/(n + 1) * sin(k / (n + 1) * π)^2 for k = n:-1:1])
+        Base.depwarn("`gausschebyshev(n, 2)` is deprecated and will be removed in the next breaking release. Please use `gausschebyshev2(n)` instead.", :gausschebyshev)
+        return gausschebyshev2(n)
     elseif kind == 3
         # Gauss-ChebyshevV quadrature, i.e., w(x) = sqrt((1+x)/(1-x))
-        return ([cos((k - .5) * π / (n + .5)) for k = n:-1:1],
-                [2π / (n + .5) * cos((k - .5) * π / (2 * (n + .5)))^2 for k = n:-1:1])
+        Base.depwarn("`gausschebyshev(n, 3)` is deprecated and will be removed in the next breaking release. Please use `gausschebyshev3(n)` instead.", :gausschebyshev)
+        return gausschebyshev3(n)
     elseif kind == 4
         # Gauss-ChebyshevW quadrature, i.e., w(x) = sqrt((1-x)/(1+x))
-        return ([cos(k * π / (n + .5)) for k = n:-1:1],
-                [2π / (n + .5) * sin(k * π / (2 * (n + .5)))^2 for k = n:-1:1])
+        Base.depwarn("`gausschebyshev(n, 4)` is deprecated and will be removed in the next breaking release. Please use `gausschebyshev4(n)` instead.", :gausschebyshev)
+        return gausschebyshev4(n)
     else
         throw(ArgumentError("Chebyshev kind should be 1, 2, 3, or 4"))
     end

--- a/src/gausschebyshev.jl
+++ b/src/gausschebyshev.jl
@@ -19,7 +19,12 @@ julia> I ≈ 3π/8
 true
 ```
 """
-gausschebyshev1(n::Integer) = [cos((2 * k - 1) * π / (2 * n)) for k = n:-1:1], fill(π / n, n)
+function gausschebyshev1(n::Integer)
+    if n < 0
+        throw(DomainError(n, "Input n must be a non-negative integer"))
+    end
+    return [cos((2 * k - 1) * π / (2 * n)) for k = n:-1:1], fill(π / n, n)
+end
 
 @doc raw"""
     gausschebyshev2(n::Integer) -> x, w  # nodes, weights
@@ -42,7 +47,12 @@ julia> I ≈ π/16
 true
 ```
 """
-gausschebyshev2(n::Integer) = [cos(k * π / (n + 1)) for k = n:-1:1], [π/(n + 1) * sin(k / (n + 1) * π)^2 for k = n:-1:1]
+function gausschebyshev2(n::Integer)
+    if n < 0
+        throw(DomainError(n, "Input n must be a non-negative integer"))
+    end
+    return [cos(k * π / (n + 1)) for k = n:-1:1], [π/(n + 1) * sin(k / (n + 1) * π)^2 for k = n:-1:1]
+end
 
 @doc raw"""
     gausschebyshev3(n::Integer) -> x, w  # nodes, weights
@@ -65,7 +75,12 @@ julia> I ≈ 3π/8
 true
 ```
 """
-gausschebyshev3(n::Integer) = [cos((k - .5) * π / (n + .5)) for k = n:-1:1], [2π / (n + .5) * cos((k - .5) * π / (2 * (n + .5)))^2 for k = n:-1:1]
+function gausschebyshev3(n::Integer)
+    if n < 0
+        throw(DomainError(n, "Input n must be a non-negative integer"))
+    end
+    return [cos((k - .5) * π / (n + .5)) for k = n:-1:1], [2π / (n + .5) * cos((k - .5) * π / (2 * (n + .5)))^2 for k = n:-1:1]
+end
 
 @doc raw"""
     gausschebyshev4(n::Integer) -> x, w  # nodes, weights
@@ -88,7 +103,12 @@ julia> I ≈ 3π/8
 true
 ```
 """
-gausschebyshev4(n::Integer) = [cos(k * π / (n + .5)) for k = n:-1:1], [2π / (n + .5) * sin(k * π / (2 * (n + .5)))^2 for k = n:-1:1]
+function gausschebyshev4(n::Integer)
+    if n < 0
+        throw(DomainError(n, "Input n must be a non-negative integer"))
+    end
+    return [cos(k * π / (n + .5)) for k = n:-1:1], [2π / (n + .5) * sin(k * π / (2 * (n + .5)))^2 for k = n:-1:1]
+end
 
 function gausschebyshev(n::Integer, kind::Integer=1)
     # GAUSS-CHEBYSHEV NODES AND WEIGHTS.

--- a/test/test_gausschebyshev.jl
+++ b/test/test_gausschebyshev.jl
@@ -1,42 +1,42 @@
 @testset "Gauss–Chebyshev" begin
 
     @testset "Check error" begin
-        @test_throws DomainError gausschebyshev1(-1)
-        @test_throws DomainError gausschebyshev2(-1)
-        @test_throws DomainError gausschebyshev3(-1)
-        @test_throws DomainError gausschebyshev4(-1)
+        @test_throws DomainError gausschebyshevT(-1)
+        @test_throws DomainError gausschebyshevU(-1)
+        @test_throws DomainError gausschebyshevV(-1)
+        @test_throws DomainError gausschebyshevW(-1)
     end
 
     n = 10
 
     @testset "x.^2" begin
-        x, w = gausschebyshev1(n)
+        x, w = gausschebyshevT(n)
         @test dot(x.^2,w) ≈ π/2
-        x, w = gausschebyshev2(n)
+        x, w = gausschebyshevU(n)
         @test dot(x.^2,w) ≈ π/8
-        x, w = gausschebyshev3(n)
+        x, w = gausschebyshevV(n)
         @test dot(x.^2,w) ≈ π/2
-        x, w = gausschebyshev4(n)
+        x, w = gausschebyshevW(n)
         @test dot(x.^2,w) ≈ π/2
     end
 
     @testset "x^3" begin
-        x, w = gausschebyshev1(n)
+        x, w = gausschebyshevT(n)
         @test abs(dot(x.^3,w)) < 1e-15
-        x, w = gausschebyshev2(n)
+        x, w = gausschebyshevU(n)
         @test abs(dot(x.^3,w)) < 1e-15
-        x, w = gausschebyshev3(n)
+        x, w = gausschebyshevV(n)
         @test dot(x.^3,w) ≈ 3*π/8
-        x, w = gausschebyshev4(n)
+        x, w = gausschebyshevW(n)
         @test dot(x.^3,w) ≈ -3*π/8
     end
 
     @testset "deprecated" begin
         n = 42
-        @test gausschebyshev1(n) == gausschebyshev(n, 1)
-        @test gausschebyshev2(n) == gausschebyshev(n, 2)
-        @test gausschebyshev3(n) == gausschebyshev(n, 3)
-        @test gausschebyshev4(n) == gausschebyshev(n, 4)
+        @test gausschebyshevT(n) == gausschebyshev(n, 1)
+        @test gausschebyshevU(n) == gausschebyshev(n, 2)
+        @test gausschebyshevV(n) == gausschebyshev(n, 3)
+        @test gausschebyshevW(n) == gausschebyshev(n, 4)
         @test_throws ArgumentError gausschebyshev(0,5)
     end
 end

--- a/test/test_gausschebyshev.jl
+++ b/test/test_gausschebyshev.jl
@@ -1,34 +1,42 @@
 @testset "Gauss–Chebyshev" begin
 
     @testset "Check error" begin
-        @test_throws DomainError gausschebyshev(-1,1)
-        @test_throws DomainError gausschebyshev(-1,2)
-        @test_throws DomainError gausschebyshev(-1,3)
-        @test_throws DomainError gausschebyshev(-1,4)
-        @test_throws ArgumentError gausschebyshev(0,5)
+        @test_throws DomainError gausschebyshev1(-1)
+        @test_throws DomainError gausschebyshev2(-1)
+        @test_throws DomainError gausschebyshev3(-1)
+        @test_throws DomainError gausschebyshev4(-1)
     end
 
     n = 10
 
     @testset "x.^2" begin
-        x, w = gausschebyshev(n,1)
+        x, w = gausschebyshev1(n)
         @test dot(x.^2,w) ≈ π/2
-        x, w = gausschebyshev(n,2)
+        x, w = gausschebyshev2(n)
         @test dot(x.^2,w) ≈ π/8
-        x, w = gausschebyshev(n,3)
+        x, w = gausschebyshev3(n)
         @test dot(x.^2,w) ≈ π/2
-        x, w = gausschebyshev(n,4)
+        x, w = gausschebyshev4(n)
         @test dot(x.^2,w) ≈ π/2
     end
 
     @testset "x^3" begin
-        x, w = gausschebyshev(n,1)
-        @test abs(dot(x.^3,w))<1e-15
-        x, w = gausschebyshev(n,2)
-        @test abs(dot(x.^3,w))<1e-15
-        x, w = gausschebyshev(n,3)
+        x, w = gausschebyshev1(n)
+        @test abs(dot(x.^3,w)) < 1e-15
+        x, w = gausschebyshev2(n)
+        @test abs(dot(x.^3,w)) < 1e-15
+        x, w = gausschebyshev3(n)
         @test dot(x.^3,w) ≈ 3*π/8
-        x, w = gausschebyshev(n,4)
+        x, w = gausschebyshev4(n)
         @test dot(x.^3,w) ≈ -3*π/8
+    end
+
+    @testset "deprecated" begin
+        n = 42
+        @test gausschebyshev1(n) == gausschebyshev(n, 1)
+        @test gausschebyshev2(n) == gausschebyshev(n, 2)
+        @test gausschebyshev3(n) == gausschebyshev(n, 3)
+        @test gausschebyshev4(n) == gausschebyshev(n, 4)
+        @test_throws ArgumentError gausschebyshev(0,5)
     end
 end

--- a/test/test_gausschebyshev.jl
+++ b/test/test_gausschebyshev.jl
@@ -1,42 +1,42 @@
 @testset "Gauss–Chebyshev" begin
 
     @testset "Check error" begin
-        @test_throws DomainError gausschebyshevT(-1)
-        @test_throws DomainError gausschebyshevU(-1)
-        @test_throws DomainError gausschebyshevV(-1)
-        @test_throws DomainError gausschebyshevW(-1)
+        @test_throws DomainError gausschebyshevt(-1)
+        @test_throws DomainError gausschebyshevu(-1)
+        @test_throws DomainError gausschebyshevv(-1)
+        @test_throws DomainError gausschebyshevw(-1)
     end
 
     n = 10
 
     @testset "x.^2" begin
-        x, w = gausschebyshevT(n)
+        x, w = gausschebyshevt(n)
         @test dot(x.^2,w) ≈ π/2
-        x, w = gausschebyshevU(n)
+        x, w = gausschebyshevu(n)
         @test dot(x.^2,w) ≈ π/8
-        x, w = gausschebyshevV(n)
+        x, w = gausschebyshevv(n)
         @test dot(x.^2,w) ≈ π/2
-        x, w = gausschebyshevW(n)
+        x, w = gausschebyshevw(n)
         @test dot(x.^2,w) ≈ π/2
     end
 
     @testset "x^3" begin
-        x, w = gausschebyshevT(n)
+        x, w = gausschebyshevt(n)
         @test abs(dot(x.^3,w)) < 1e-15
-        x, w = gausschebyshevU(n)
+        x, w = gausschebyshevu(n)
         @test abs(dot(x.^3,w)) < 1e-15
-        x, w = gausschebyshevV(n)
+        x, w = gausschebyshevv(n)
         @test dot(x.^3,w) ≈ 3*π/8
-        x, w = gausschebyshevW(n)
+        x, w = gausschebyshevw(n)
         @test dot(x.^3,w) ≈ -3*π/8
     end
 
     @testset "deprecated" begin
         n = 42
-        @test gausschebyshevT(n) == gausschebyshev(n, 1)
-        @test gausschebyshevU(n) == gausschebyshev(n, 2)
-        @test gausschebyshevV(n) == gausschebyshev(n, 3)
-        @test gausschebyshevW(n) == gausschebyshev(n, 4)
+        @test gausschebyshevt(n) == gausschebyshev(n, 1)
+        @test gausschebyshevu(n) == gausschebyshev(n, 2)
+        @test gausschebyshevv(n) == gausschebyshev(n, 3)
+        @test gausschebyshevw(n) == gausschebyshev(n, 4)
         @test_throws ArgumentError gausschebyshev(0,5)
     end
 end


### PR DESCRIPTION
We currently have `gausschebyshev(n::Integer, kind::Integer)`, but we don't need arithmetic operations for `kind` parameter, i.e. some operations such as `gausschebyshev(4, 2+1)` is not desired.

`Enum` or `Val` can be used to solve this problem, however, just splitting and renaming the function would be enough here.

```julia
julia> gausschebyshev(5,2)  # deprecated method
([-0.8660254037844387, -0.4999999999999998, 6.123233995736766e-17, 0.5000000000000001, 0.8660254037844387], [0.13089969389957468, 0.3926990816987242, 0.5235987755982988, 0.39269908169872403, 0.13089969389957468])

julia> gausschebyshev2(5)  # new function
([-0.8660254037844387, -0.4999999999999998, 6.123233995736766e-17, 0.5000000000000001, 0.8660254037844387], [0.13089969389957468, 0.3926990816987242, 0.5235987755982988, 0.39269908169872403, 0.13089969389957468])
```