### PR TITLE
Deprecate `besselroots` function

### DIFF
--- a/src/besselroots.jl
+++ b/src/besselroots.jl
@@ -218,7 +218,4 @@ function besselJ1(m)
     return Jk2
 end
 
-function besselroots(ν::Real, n::Integer)
-    @warn "`besselroots` has been renamed to `approx_besselroots`, and `besselroots` will be removed in the next major release."
-    return approx_besselroots(ν, n)
-end
+Base.@deprecate besselroots(ν::Real, n::Integer) approx_besselroots(ν, n)

--- a/test/test_besselroots.jl
+++ b/test/test_besselroots.jl
@@ -1,8 +1,7 @@
 @testset "Bessel Roots" begin
     @test_throws DomainError approx_besselroots(0.0, -1)
 
-    msg = "`besselroots` has been renamed to `approx_besselroots`, and `besselroots` will be removed in the next major release."
-    @test_logs (:warn, msg) besselroots(0.2,3)
+    @test_deprecated besselroots(0.2,3)
 
     # Check if besselj(ν, approx_besselroots(ν, n) ) is small:
     tol = 1e-11


### PR DESCRIPTION
`Base.@deprecate` is better than `@warn` here.