### PR TITLE
Update make.jl for Documenter.jl v1.0.0

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,6 +9,7 @@ makedocs(;
     format = Documenter.HTML(
         canonical = "https://JuliaApproximation.github.io/FastGaussQuadrature.jl/stable/",
         assets = ["assets/favicon.ico"],
+        repolink = "https://github.com/JuliaApproximation/FastGaussQuadrature.jl"
     ),
     pages = [
         "Home" => "index.md",
@@ -21,7 +22,6 @@ makedocs(;
     repo = "https://github.com/JuliaApproximation/FastGaussQuadrature.jl/blob/{commit}{path}#L{line}",
     sitename = "FastGaussQuadrature.jl",
     authors = "Alex Townsend, Sheehan Olver, Peter Opsomer, and contributors.",
-    assets = String[],
 )
 
 deploydocs(; repo = "github.com/JuliaApproximation/FastGaussQuadrature.jl")


### PR DESCRIPTION
The CI for documentation is failing: https://github.com/JuliaApproximation/FastGaussQuadrature.jl/actions/runs/6200004665/job/16833735160

This PR fixes this problem.