### PR TITLE
fix deprecation warnings - constraint LinearAlgebra

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 Aqua = "0.7"
+LinearAlgebra = "1"
 SpecialFunctions = "0.7, 0.8, 0.9, 0.10, 1.0, 2"
 StaticArrays = "1.0"
 julia = "1.6"
@@ -19,4 +20,4 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random", "Aqua"]
+test = ["Aqua", "Random", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FastGaussQuadrature"
 uuid = "442a2c76-b920-505d-bb47-c5924d526838"
-version = "1.0.1"
+version = "1.0.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/gaussjacobi.jl
+++ b/src/gaussjacobi.jl
@@ -27,13 +27,13 @@ function gaussjacobi(n::Integer, α::Real, β::Real)
     elseif α == 0. && β == 0.
         gausslegendre(n)
     elseif α == -0.5 && β == -0.5
-        gausschebyshev(n, 1)
+        gausschebyshevt(n)
     elseif α == 0.5 && β == 0.5
-        gausschebyshev(n, 2)
+        gausschebyshevu(n)
     elseif α == -0.5 && β == 0.5
-        gausschebyshev(n, 3)
+        gausschebyshevv(n)
     elseif α == 0.5 && β == -0.5
-        gausschebyshev(n, 4)
+        gausschebyshevw(n)
     elseif n == 0
         Float64[], Float64[]
     elseif n == 1

--- a/test/test_gausschebyshev.jl
+++ b/test/test_gausschebyshev.jl
@@ -33,10 +33,10 @@
 
     @testset "deprecated" begin
         n = 42
-        @test gausschebyshevt(n) == gausschebyshev(n, 1)
-        @test gausschebyshevu(n) == gausschebyshev(n, 2)
-        @test gausschebyshevv(n) == gausschebyshev(n, 3)
-        @test gausschebyshevw(n) == gausschebyshev(n, 4)
+        @test gausschebyshevt(n) == @test_deprecated gausschebyshev(n, 1)
+        @test gausschebyshevu(n) == @test_deprecated gausschebyshev(n, 2)
+        @test gausschebyshevv(n) == @test_deprecated gausschebyshev(n, 3)
+        @test gausschebyshevw(n) == @test_deprecated gausschebyshev(n, 4)
         @test_throws ArgumentError gausschebyshev(0,5)
     end
 end

--- a/test/test_gaussjacobi.jl
+++ b/test/test_gaussjacobi.jl
@@ -46,7 +46,7 @@
         α₋ = prevfloat(α₀)
         β₋ = prevfloat(β₀)
         for n in n_range
-            x, w = gausschebyshev(n, 1)
+            x, w = @test_deprecated gausschebyshev(n, 1)
             x₀₀, w₀₀ = gaussjacobi(n, α₀, β₀)
             x₀₊, w₀₊ = gaussjacobi(n, α₀, β₊)
             x₀₋, w₀₋ = gaussjacobi(n, α₀, β₋)
@@ -73,7 +73,7 @@
         α₋ = prevfloat(α₀)
         β₋ = prevfloat(β₀)
         for n in n_range
-            x, w = gausschebyshev(n, 2)
+            x, w = @test_deprecated gausschebyshev(n, 2)
             x₀₀, w₀₀ = gaussjacobi(n, α₀, β₀)
             x₀₊, w₀₊ = gaussjacobi(n, α₀, β₊)
             x₀₋, w₀₋ = gaussjacobi(n, α₀, β₋)
@@ -100,7 +100,7 @@
         α₋ = prevfloat(α₀)
         β₋ = prevfloat(β₀)
         for n in n_range
-            x, w = gausschebyshev(n, 3)
+            x, w = @test_deprecated gausschebyshev(n, 3)
             x₀₀, w₀₀ = gaussjacobi(n, α₀, β₀)
             x₀₊, w₀₊ = gaussjacobi(n, α₀, β₊)
             x₀₋, w₀₋ = gaussjacobi(n, α₀, β₋)
@@ -127,7 +127,7 @@
         α₋ = prevfloat(α₀)
         β₋ = prevfloat(β₀)
         for n in n_range
-            x, w = gausschebyshev(n, 4)
+            x, w = @test_deprecated gausschebyshev(n, 4)
             x₀₀, w₀₀ = gaussjacobi(n, α₀, β₀)
             x₀₊, w₀₊ = gaussjacobi(n, α₀, β₊)
             x₀₋, w₀₋ = gaussjacobi(n, α₀, β₋)


### PR DESCRIPTION
This PR:

- fixes deprecation warning when using `gaussjacobi` with `julia --depwarn=yes` (introduced in https://github.com/JuliaApproximation/FastGaussQuadrature.jl/pull/123);
- fixes test suite to avoid deprecation warnings when running under `julia --depwarn=yes`;
- add `LinearAlgebra` compat entry per [PSA](https://discourse.julialang.org/t/psa-compat-requirements-in-the-general-registry-are-changing/104958).

cc @hyrodium, @dlfivefifty.