### PR TITLE
Return an `SVector` in `piessens`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FastGaussQuadrature"
 uuid = "442a2c76-b920-505d-bb47-c5924d526838"
-version = "1.0.2"
+version = "1.0.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/besselroots.jl
+++ b/src/besselroots.jl
@@ -137,9 +137,7 @@ function piessens(ν::Float64)
     C = PIESSENS_C
     T = _piessens_chebyshev30(ν)
     y = C'*T
-    _y = collect(y)
-    _y[1] *= sqrt(ν+1)  # Scale the first root.
-    return _y
+    return Base.setindex(y, y[1] * sqrt(ν+1), 1)
 end
 
 


### PR DESCRIPTION
This should reduce some allocations. After this,
```julia
(FastGaussQuadrature) julia> piessens(0.0)
6-element SVector{6, Float64} with indices SOneTo(6):
  2.40482555769751
  5.520078110288018
  8.653727912912164
 11.791534439013164
 14.930917708486993
 18.071063967911865
```
We don't need the allocation here.