### PR TITLE
Reduce the allocations of gausslegendre for moderate n and add a flag for Aqua

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         env:
           cache-name: cache-artifacts
         with:

--- a/src/gausslegendre.jl
+++ b/src/gausslegendre.jl
@@ -203,9 +203,10 @@ end
 function rec(n)
     # COMPUTE GAUSS-LEGENDRE NODES AND WEIGHTS USING NEWTON'S METHOD.
     # THREE-TERM RECURENCE IS USED FOR EVALUATION. COMPLEXITY O(n^2).
-    # Initial guesses:
-    x0 = asy(n)[1]
-    x = x0[1:n ÷ 2 + 1]
+    
+    # Initial guess:
+    x=leg_initial_guess(n)
+
     # Perform Newton to find zeros of Legendre polynomial:
     PP1,PP2=similar(x),similar(x)
 
@@ -255,4 +256,16 @@ end
     @inbounds @simd for i in eachindex(x)
         x[i] -= PP1[i] / PP2[i]
     end
+end
+
+function leg_initial_guess(n)
+    # Returns an approximation of the first n÷2+1 roots of the Legendre polynomial.
+    #  The following is equivalent to "x0=asy(n);x = x0[1:n ÷ 2 + 1]" but it avoids unnecessary calculations.
+
+    m = (n + 1) >> 1
+    a = besselZeroRoots(m)
+    rmul!(a, 1 / (n + 0.5))
+    x = legpts_nodes(n, a)
+    rmul!(x,-1.0)
+    return x
 end

--- a/src/gausslegendre.jl
+++ b/src/gausslegendre.jl
@@ -207,14 +207,12 @@ function rec(n)
     x0 = asy(n)[1]
     x = x0[1:n ÷ 2 + 1]
     # Perform Newton to find zeros of Legendre polynomial:
-    PP1, PP2 = innerRec(n, x)
-    @inbounds @simd for i in 1:length(x)
-        x[i] -= PP1[i] / PP2[i]
-    end
-        # One more Newton for derivatives:
-    PP1, PP2 = innerRec(n, x)
-    @inbounds @simd for i in 1:length(x)
-        x[i] -= PP1[i] / PP2[i]
+    PP1,PP2=similar(x),similar(x)
+
+    # Two iterations of Newton's method
+    for _=1:2
+        innerRec!(PP1,PP2,n, x)
+        newt_step!(x,PP1,PP2)
     end
 
     # Use symmetry to get the other Legendre nodes and weights:
@@ -232,11 +230,9 @@ function rec(n)
     return x, PP2
 end
 
-function innerRec(n, x)
+@inline function innerRec!(myPm1,myPPm1,n, x)
     # EVALUATE LEGENDRE AND ITS DERIVATIVE USING THREE-TERM RECURRENCE RELATION.
     N = size(x, 1)
-    myPm1 = Array{Float64}(undef, N)
-    myPPm1 = Array{Float64}(undef, N)
     @inbounds for j = 1:N
         xj = x[j]
         Pm2 = 1.0
@@ -252,4 +248,11 @@ function innerRec(n, x)
         myPPm1[j] = PPm1
     end
     return myPm1, myPPm1
+end
+
+@inline function newt_step!(x,PP1,PP2)
+    # In-place iteration of Newton's method.
+    @inbounds @simd for i in eachindex(x)
+        x[i] -= PP1[i] / PP2[i]
+    end
 end

--- a/src/gausslegendre.jl
+++ b/src/gausslegendre.jl
@@ -262,7 +262,7 @@ function leg_initial_guess(n)
     # Returns an approximation of the first n÷2+1 roots of the Legendre polynomial.
     #  The following is equivalent to "x0=asy(n);x = x0[1:n ÷ 2 + 1]" but it avoids unnecessary calculations.
 
-    m = (n + 1) >> 1
+    m = (n ÷2) +1
     a = besselZeroRoots(m)
     rmul!(a, 1 / (n + 0.5))
     x = legpts_nodes(n, a)

--- a/src/gausslegendre.jl
+++ b/src/gausslegendre.jl
@@ -258,7 +258,7 @@ end
     end
 end
 
-function leg_initial_guess(n)
+@inline function leg_initial_guess(n)
     # Returns an approximation of the first n÷2+1 roots of the Legendre polynomial.
     #  The following is equivalent to "x0=asy(n);x = x0[1:n ÷ 2 + 1]" but it avoids unnecessary calculations.
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using FastGaussQuadrature
 using Test, Aqua, LinearAlgebra, Random, SpecialFunctions
 
-Aqua.test_all(FastGaussQuadrature)
+Aqua.test_all(FastGaussQuadrature;deps_compat = (; check_extras=false))
 
 @testset "FastGaussQuadrature.jl" begin
     include("test_gausschebyshev.jl")


### PR DESCRIPTION
Hi,


## Reducing allocations:

The Newton's iteration for `gausslegendre` uses only part of the information returned by the asymptotic formula `asy`. I stripped the relevant code from `asy` to a new function `leg_initial_guess` to reduce allocations and improve performance. I have also reused the temporary vectors `PP1` and `PP2`.  This reduces allocations in `rec(n)` from 22 to 9. 

**Example 1**
Current  Master:
```julia
julia> @btime gausslegendre(10)
  541.186 ns (22 allocations: 1.36 KiB)
```
With this PR:
```julia
julia> @btime gausslegendre(10)
  396.139 ns (9 allocations: 640 bytes)
```

This performance improvement is less pronounced for higher values of `n` since the Newton iteration is O(n^2). 

**Example 2**
Current  Master:
```julia
julia> @btime gausslegendre(50)
  10.787 μs (22 allocations: 5.52 KiB)
```
With this PR:
```julia
julia> @btime gausslegendre(50)
  10.379 μs (9 allocations: 2.62 KiB)
```


## CI and Aqua 

Currently the test are not passing since `actions/cache@v1` is deprecated, and `Aqua.jl` is indicating that the packages in `extras` do not have a compat entry. I have upgraded the  `actions/cache` version, and added a flag to `Aqua` to ignore packages in extra. All tests pass now. 


Best,
Haroun 