### PR TITLE
Support arbitrary type for `gausslobatto`, `gausshermite`, and `gausslaguerre`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FastGaussQuadrature"
 uuid = "442a2c76-b920-505d-bb47-c5924d526838"
-version = "1.2.0"
+version = "1.3.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/gausshermite.jl
+++ b/src/gausshermite.jl
@@ -109,7 +109,6 @@ function hermite_rec(::Type{T}, n::Integer) where {T <: AbstractFloat}
 
     return x0, w
 end
-hermite_rec(n::Integer) = hermite_rec(Float64, n)
 
 function hermpoly_rec(n::Integer, x0)
     # HERMPOLY_rec evaluation of scaled Hermite poly using recurrence

--- a/src/gausshermite.jl
+++ b/src/gausshermite.jl
@@ -32,7 +32,7 @@ function gausshermite(::Type{T}, n::Integer; normalize = false) where {T}
 end
 gausshermite(n::Integer; normalize = false) = gausshermite(Float64, n; normalize = normalize)
 
-function unweightedgausshermite(::Type{T}, n::Integer) where {T <: AbstractFloat}
+function unweightedgausshermite(::Type{T}, n::Integer) where {T <: Real}
     # GAUSSHERMITE(n) COMPUTE THE GAUSS-HERMITE NODES AND WEIGHTS IN O(n) time.
     if n < 0
         throw(DomainError(n, "Input n must be a non-negative integer"))
@@ -322,7 +322,7 @@ function hermite_initialguess(n::Integer)
     return x_init
 end
 
-function hermite_gw(::Type{T}, n::Integer) where {T <: AbstractFloat}
+function hermite_gw(::Type{T}, n::Integer) where {T <: Real}
     # Golub--Welsch algorithm. Used here for n ≤ 20.
 
     beta = sqrt.(T.(1:(n - 1)) / 2)  # 3-term recurrence coeffs

--- a/src/gausshermite.jl
+++ b/src/gausshermite.jl
@@ -1,7 +1,7 @@
 @doc raw"""
-    gausshermite(n::Integer; normalize = false) -> x, w  # nodes, weights
+    gausshermite([T=Float64,] n::Integer; normalize = false) -> x, w  # nodes, weights
 
-Return nodes `x` and weights `w` of [Gauss-Hermite quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Hermite_quadrature).
+Return nodes `x` and weights `w` of [Gauss-Hermite quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Hermite_quadrature) with type `T`.
 
 ```math
 \int_{-\infty}^{+\infty} f(x) \exp(-x^2) dx \approx \sum_{i=1}^{n} w_i f(x_i)
@@ -25,26 +25,27 @@ julia> I ≈ 3(√π)/4
 true
 ```
 """
-function gausshermite(n::Integer; normalize = false)
-    x, w = unweightedgausshermite(n)
+function gausshermite(::Type{T}, n::Integer; normalize = false) where {T <: AbstractFloat}
+    x, w = unweightedgausshermite(T, n)
     w .*= exp.(-x .^ 2)
-    return normalize ? (sqrt(2.0) * x, w / sqrt(π)) : (x, w)
+    return normalize ? (sqrt(T(2)) * x, w / sqrt(T(π))) : (x, w)
 end
+gausshermite(n::Integer; normalize = false) = gausshermite(Float64, n; normalize = normalize)
 
-function unweightedgausshermite(n::Integer)
+function unweightedgausshermite(::Type{T}, n::Integer) where {T <: AbstractFloat}
     # GAUSSHERMITE(n) COMPUTE THE GAUSS-HERMITE NODES AND WEIGHTS IN O(n) time.
     if n < 0
         throw(DomainError(n, "Input n must be a non-negative integer"))
     elseif n == 0
-        return Float64[], Float64[]
+        return T[], T[]
     elseif n == 1
-        return [0.0], [sqrt(π)]
+        return T[0], T[sqrt(T(π))]
     elseif n ≤ 20
         # GW algorithm
-        x = hermite_gw(n)
-    elseif n ≤ 200
+        x = hermite_gw(T, n)
+    elseif n ≤ 200 || T != Float64
         # REC algorithm
-        x = hermite_rec(n)
+        x = hermite_rec(T, n)
     else
         # ASY algorithm
         x = hermite_asy(n)
@@ -58,10 +59,11 @@ function unweightedgausshermite(n::Integer)
         _w = [reverse(x[2][:]); x[2][:]]
         _x = [-reverse(x[1]) ; x[1]]
     end
-    _w .*= sqrt(π) / sum(exp.(-_x .^ 2) .* _w)
+    _w .*= sqrt(T(π)) / sum(exp.(-_x .^ 2) .* _w)
 
     return _x, _w
 end
+unweightedgausshermite(n::Integer) = unweightedgausshermite(Float64, n)
 
 function hermite_asy(n::Integer)
     # Compute Hermite nodes and weights using asymptotic formula
@@ -86,26 +88,28 @@ function hermite_asy(n::Integer)
     return x, w
 end
 
-function hermite_rec(n::Integer)
+function hermite_rec(::Type{T}, n::Integer) where {T <: AbstractFloat}
     # Compute Hermite nodes and weights using recurrence relation.
 
-    x0 = hermite_initialguess(n)
-    x0 .*= sqrt(2)
+    x0 = T.(hermite_initialguess(n))
+    x0 .*= sqrt(T(2))
     val = x0
-    for _ in 1:10
+    num_iters = T == Float64 ? 10 : ceil(Int, (log(max(20, precision(T)) / 50) + 1) * 10)
+    for _ in 1:num_iters
         val = hermpoly_rec.(n, x0)
         dx = first.(val) ./ last.(val)
         dx[isnan.(dx)] .= 0
         x0 .= x0 .- dx
-        if norm(dx, Inf) < sqrt(eps(Float64))
+        if norm(dx, Inf) < sqrt(eps(T))
             break
         end
     end
-    x0 ./= sqrt(2)
+    x0 ./= sqrt(T(2))
     w = 1 ./ last.(val) .^ 2  # quadrature weights
 
     return x0, w
 end
+hermite_rec(n::Integer) = hermite_rec(Float64, n)
 
 function hermpoly_rec(n::Integer, x0)
     # HERMPOLY_rec evaluation of scaled Hermite poly using recurrence
@@ -117,7 +121,7 @@ function hermpoly_rec(n::Integer, x0)
     # n == 0 && return (Hold, 0)
     H = x0
     for k in 1:(n - 1)
-        Hold, H = H, (x0 * H / sqrt(k + 1) - Hold / sqrt(1 + 1 / k))
+        Hold, H = H, (x0 * H / sqrt(oftype(x0, k + 1)) - Hold / sqrt(oftype(x0, k + 1) / k))
         while abs(H) ≥ 100 && wc < n  # regularise
             H *= w
             Hold *= w
@@ -130,7 +134,7 @@ function hermpoly_rec(n::Integer, x0)
         Hold *= w
     end
 
-    return H, -x0 * H + sqrt(n) * Hold
+    return H, -x0 * H + sqrt(oftype(x0, n)) * Hold
 end
 
 function hermpoly_rec(r::Base.OneTo, x0)
@@ -319,15 +323,15 @@ function hermite_initialguess(n::Integer)
     return x_init
 end
 
-function hermite_gw(n::Integer)
+function hermite_gw(::Type{T}, n::Integer) where {T <: AbstractFloat}
     # Golub--Welsch algorithm. Used here for n ≤ 20.
 
-    beta = sqrt.((1:(n - 1)) / 2)  # 3-term recurrence coeffs
-    T = SymTridiagonal(zeros(n), beta)  # Jacobi matrix
-    D, V = eigen(T)  # Eigenvalue decomposition
+    beta = sqrt.(T.(1:(n - 1)) / 2)  # 3-term recurrence coeffs
+    J = SymTridiagonal(zeros(T, n), beta)  # Jacobi matrix
+    D, V = eigen(J)  # Eigenvalue decomposition
     ind = sortperm(D)  # Hermite points
     x = D[ind]  # nodes
-    w = sqrt(π) * V[1, ind] .^ 2  # weights
+    w = sqrt(T(π)) * V[1, ind] .^ 2  # weights
 
     # Enforce symmetry:
     i = (floor(Int, n / 2) + 1):n
@@ -335,3 +339,4 @@ function hermite_gw(n::Integer)
     w = w[i]
     return x, exp.(x .^ 2) .* w
 end
+hermite_gw(n::Integer) = hermite_gw(Float64, n)

--- a/src/gausshermite.jl
+++ b/src/gausshermite.jl
@@ -25,7 +25,7 @@ julia> I ≈ 3(√π)/4
 true
 ```
 """
-function gausshermite(::Type{T}, n::Integer; normalize = false) where {T <: AbstractFloat}
+function gausshermite(::Type{T}, n::Integer; normalize = false) where {T}
     x, w = unweightedgausshermite(T, n)
     w .*= exp.(-x .^ 2)
     return normalize ? (sqrt(T(2)) * x, w / sqrt(T(π))) : (x, w)

--- a/src/gausslaguerre.jl
+++ b/src/gausslaguerre.jl
@@ -1,7 +1,7 @@
 @doc raw"""
-    gausslaguerre(n::Integer) -> x, w  # nodes, weights
+    gausslaguerre([T=Float64,] n::Integer) -> x, w  # nodes, weights
 
-Return nodes `x` and weights `w` of [Gauss-Laguerre quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Laguerre_quadrature).
+Return nodes `x` and weights `w` of [Gauss-Laguerre quadrature](https://en.wikipedia.org/wiki/Gauss%E2%80%93Laguerre_quadrature) with type `T`.
 
 ```math
 \int_{0}^{+\infty} f(x) e^{-x} dx \approx \sum_{i=1}^{n} w_i f(x_i)
@@ -19,10 +19,8 @@ julia> I ≈ 24
 true
 ```
 """
-function gausslaguerre(n::Integer)
-    return gausslaguerre(n, 0.0)
-end
-
+gausslaguerre(::Type{T}, n::Integer) where {T <: AbstractFloat} = gausslaguerre(n, T(0))
+gausslaguerre(n::Integer) = gausslaguerre(Float64, n)
 
 @doc raw"""
     gausslaguerre(n::Integer, α::Real) -> x, w  # nodes, weights
@@ -82,8 +80,9 @@ function gausslaguerre(n::Integer, α::Real; reduced = false)
     elseif n < 15
         # Use Golub-Welsch for small n
         return gausslaguerre_GW(n, α)
-    elseif n < 128
-        # Use the recurrence relation for moderate n
+    elseif n < 128 || T != Float64
+        # Use the recurrence relation for moderate n, and for non-Float64 types
+        # (gausslaguerre_asy uses Float64-specific heuristics)
         return gausslaguerre_rec(n, α)
     else
         # Use explicit asymptotic expansions for larger n

--- a/src/gausslaguerre.jl
+++ b/src/gausslaguerre.jl
@@ -1,3 +1,4 @@
+gausslaguerre(::Type{T}, n::Integer) where {T} = gausslaguerre(n, T(0))
 @doc raw"""
     gausslaguerre([T=Float64,] n::Integer) -> x, w  # nodes, weights
 
@@ -19,7 +20,6 @@ julia> I ≈ 24
 true
 ```
 """
-gausslaguerre(::Type{T}, n::Integer) where {T <: AbstractFloat} = gausslaguerre(n, T(0))
 gausslaguerre(n::Integer) = gausslaguerre(Float64, n)
 
 @doc raw"""

--- a/src/gausslobatto.jl
+++ b/src/gausslobatto.jl
@@ -1,7 +1,7 @@
 @doc raw"""
-    gausslobatto(n::Integer) -> x, w  # nodes, weights
+    gausslobatto([T=Float64,] n::Integer) -> x, w  # nodes, weights
 
-Return nodes `x` and weights `w` of [Gauss-Lobatto quadrature](https://mathworld.wolfram.com/LobattoQuadrature.html).
+Return nodes `x` and weights `w` of [Gauss-Lobatto quadrature](https://mathworld.wolfram.com/LobattoQuadrature.html) with type `T`.
 
 ```math
 \int_{-1}^{1} f(x) dx \approx \sum_{i=1}^{n} w_i f(x_i)
@@ -28,24 +28,25 @@ julia> x[1], x[end]
 (-1.0, 1.0)
 ```
 """
-function gausslobatto(n::Integer)
+function gausslobatto(::Type{T}, n::Integer) where {T}
     # Gauss-Legendre-Lobatto Quadrature Nodes and Weights
     if n ≤ 1
         throw(DomainError(n, "Lobatto undefined for n ≤ 1."))
     elseif n == 2
-        return [-1.0, 1.0], [1.0, 1.0]
+        return T[-1, 1], T[1, 1]
     elseif n == 3
-        return [-1.0, 0.0, 1.0], [1.0 / 3, 4.0 / 3, 1.0 / 3]
+        return T[-1, 0, 1], [T(1) / 3, T(4) / 3, T(1) / 3]
     else
         # Compute via GaussJacobi:
-        x, w = gaussjacobi(n - 2, 1.0, 1.0)
+        x, w = gaussjacobi(n - 2, T(1), T(1))
         @inbounds for i in 1:length(x)
             w[i] = w[i] / (1 - x[i]^2)
         end
-        pushfirst!(x, -1.0)
-        push!(x, 1.0)
-        pushfirst!(w, 2 / (n * (n - 1)))
-        push!(w, 2 / (n * (n - 1)))
+        pushfirst!(x, T(-1))
+        push!(x, T(1))
+        pushfirst!(w, T(2) / (n * (n - 1)))
+        push!(w, T(2) / (n * (n - 1)))
         return x, w
     end
 end
+gausslobatto(n::Integer) = gausslobatto(Float64, n)

--- a/test/test_bigfloatcoefs.jl
+++ b/test/test_bigfloatcoefs.jl
@@ -23,7 +23,7 @@ end
 @testset "Gauss–Hermite" begin
     # n values cover: special cases (1), GW (≤20), rec (21–200), asy→rec for BigFloat (>200)
     @testset "n: $n" for n in (1, 2, 10, 21, 100, 250)
-        x, w = gausshermite(n)
+        x, w = @inferred gausshermite(n)
         xbig, wbig = @inferred gausshermite(BigFloat, n)
         @test length(xbig) == n && length(wbig) == n
         @test ≈(x, xbig; atol = n ≤ 200 ? 1.0e-14 : 1.0e-13)
@@ -36,7 +36,7 @@ end
 @testset "Gauss–Laguerre" begin
     # n values cover: special cases (1,2), GW (<15), rec (15–127), asy→rec for BigFloat (≥128)
     @testset "n: $n" for n in (1, 2, 3, 10, 20, 130)
-        x, w = gausslaguerre(n)
+        x, w = @inferred gausslaguerre(n)
         xbig, wbig = @inferred gausslaguerre(BigFloat, n)
         @test length(xbig) == n && length(wbig) == n
         @test ≈(x, xbig; atol = n < 128 ? 1.0e-13 : 1.0e-12)
@@ -48,8 +48,8 @@ end
     # non-zero α: type inferred from α, or set explicitly via T
     @testset "α ≠ 0, n: $n" for n in (3, 10, 20, 130)
         α = 0.5
-        x, w = gausslaguerre(n, α)
-        xbig, wbig = gausslaguerre(n, big(α))
+        x, w = @inferred gausslaguerre(n, α)
+        xbig, wbig = @inferred gausslaguerre(n, big(α))
         @test ≈(x, xbig; atol = 1.0e-12)
         @test ≈(w, wbig; atol = 1.0e-14)
         # ∫ x * x^α exp(-x) dx = Γ(α+2), exact for n ≥ 1
@@ -60,7 +60,7 @@ end
 @testset "Gauss–Lobatto" begin
     @testset "n: $n" for n in (3, 4, 5, 6, 7, 8, 9, 40, 100)
         # check BigFloat
-        x, w = gausslobatto(n)
+        x, w = @inferred gausslobatto(n)
         xbig, wbig = @inferred gausslobatto(BigFloat, n)
         @test length(xbig) == n && length(wbig) == n
         @test ≈(x, xbig; atol = 1.0e-14)

--- a/test/test_bigfloatcoefs.jl
+++ b/test/test_bigfloatcoefs.jl
@@ -19,3 +19,20 @@ using LinearAlgebra, GenericLinearAlgebra
         end
     end
 end
+
+@testset "Gauss–Lobatto" begin
+    @testset "n: $n" for n in (3, 4, 5, 6, 7, 8, 9, 40, 100)
+        # check BigFloat
+        x, w = gausslobatto(n)
+        xbig, wbig = @inferred gausslobatto(BigFloat, n)
+        @test length(xbig) == n && length(wbig) == n
+        @test ≈(x, xbig; atol = 1.0e-14)
+        @test ≈(w, wbig; atol = 1.0e-14)
+        # tests bigfloat coefs by integrating against a polynomial of degree 2n-3
+        # (exact for Lobatto with n points, which integrates degree 2n-3 exactly)
+        poly_coefs = FastGaussQuadrature.jacobi_gw(2n - 3, big(0.0), big(0.0))[1]
+        test_fun(x) = evalpoly(x, poly_coefs)
+        integral_testfun(x) = x * evalpoly(x, [p / i for (i, p) in enumerate(poly_coefs)])
+        @test ≈(dot(wbig, test_fun.(xbig)), integral_testfun(1) - integral_testfun(-1); atol = 1.0e-70)
+    end
+end

--- a/test/test_bigfloatcoefs.jl
+++ b/test/test_bigfloatcoefs.jl
@@ -20,6 +20,43 @@ using LinearAlgebra, GenericLinearAlgebra
     end
 end
 
+@testset "Gauss–Hermite" begin
+    # n values cover: special cases (1), GW (≤20), rec (21–200), asy→rec for BigFloat (>200)
+    @testset "n: $n" for n in (1, 2, 10, 21, 100, 250)
+        x, w = gausshermite(n)
+        xbig, wbig = @inferred gausshermite(BigFloat, n)
+        @test length(xbig) == n && length(wbig) == n
+        @test ≈(x, xbig; atol = n ≤ 200 ? 1.0e-14 : 1.0e-13)
+        @test ≈(w, wbig; atol = n ≤ 200 ? 1.0e-14 : 1.0e-12)
+        # ∫ x^2 exp(-x^2) dx = sqrt(π)/2, exact for n ≥ 2
+        n ≥ 2 && @test ≈(dot(wbig, xbig .^ 2), sqrt(big(π)) / 2; atol = n == 21 ? 1.0e-50 : 1.0e-70)
+    end
+end
+
+@testset "Gauss–Laguerre" begin
+    # n values cover: special cases (1,2), GW (<15), rec (15–127), asy→rec for BigFloat (≥128)
+    @testset "n: $n" for n in (1, 2, 3, 10, 20, 130)
+        x, w = gausslaguerre(n)
+        xbig, wbig = @inferred gausslaguerre(BigFloat, n)
+        @test length(xbig) == n && length(wbig) == n
+        @test ≈(x, xbig; atol = n < 128 ? 1.0e-13 : 1.0e-12)
+        @test ≈(w, wbig; atol = 1.0e-13)
+        # ∫ x exp(-x) dx = 1, exact for n ≥ 2
+        n ≥ 2 && @test ≈(dot(wbig, xbig), big(1); atol = 1.0e-70)
+    end
+
+    # non-zero α: type inferred from α, or set explicitly via T
+    @testset "α ≠ 0, n: $n" for n in (3, 10, 20, 130)
+        α = 0.5
+        x, w = gausslaguerre(n, α)
+        xbig, wbig = gausslaguerre(n, big(α))
+        @test ≈(x, xbig; atol = 1.0e-12)
+        @test ≈(w, wbig; atol = 1.0e-14)
+        # ∫ x * x^α exp(-x) dx = Γ(α+2), exact for n ≥ 1
+        @test ≈(dot(wbig, xbig), gamma(big(α) + 2); atol = 1.0e-70)
+    end
+end
+
 @testset "Gauss–Lobatto" begin
     @testset "n: $n" for n in (3, 4, 5, 6, 7, 8, 9, 40, 100)
         # check BigFloat

--- a/test/test_bigfloatcoefs.jl
+++ b/test/test_bigfloatcoefs.jl
@@ -4,7 +4,7 @@ using LinearAlgebra, GenericLinearAlgebra
     @testset "quad: $quad" for quad in (gausslegendre, gaussradau)
         @testset "n: $n" for n in (2, 3, 4, 5, 6, 7, 8, 9, 40, 100)
             # check BigFloat
-            x, w = quad(n)
+            x, w = @inferred quad(n)
             xbig, wbig = @inferred quad(BigFloat, n)
             @test length(xbig) == n && length(wbig) == n
             @test ≈(x, xbig; atol = 1.0e-14)

--- a/test/test_gausshermite.jl
+++ b/test/test_gausshermite.jl
@@ -73,6 +73,12 @@
         @test FastGaussQuadrature.hermpoly_rec(0:(20^2), 20)[end] ≈ FastGaussQuadrature.hermpoly_rec(20^2, 20)[1]
     end
 
+    @testset "Type inference" begin
+        @inferred gausshermite(Float32, 10)
+        @inferred gausshermite(BigFloat, 10)
+        @inferred gausshermite(BigFloat, 250)
+    end
+
     @testset "Normalize" begin
         for t in 1:6
             x, w = gausshermite(t; normalize = true)

--- a/test/test_gausslaguerre.jl
+++ b/test/test_gausslaguerre.jl
@@ -37,6 +37,16 @@ Random.seed!(0)
     @test_throws DomainError gausslaguerre(1, -1.4)
     @test_throws DomainError gausslaguerre(-1)
 
+    # Type inference
+    @inferred gausslaguerre(Float32, 10)
+    @inferred gausslaguerre(BigFloat, 10)
+    @inferred gausslaguerre(BigFloat, 130)
+
+    α = 0.5
+    @inferred gausslaguerre(10, Float32(α))
+    @inferred gausslaguerre(10, big(α))
+    @inferred gausslaguerre(130, big(α))
+
     # Check optional argument
     for n in 0:20
         @test gausslaguerre(n) == gausslaguerre(n, 0) == gausslaguerre(n, 0.0)

--- a/test/test_gausslobatto.jl
+++ b/test/test_gausslobatto.jl
@@ -4,6 +4,10 @@
     @test_throws DomainError gausslobatto(0)
     @test_throws DomainError gausslobatto(1)
 
+    # Type stability
+    @inferred gausslobatto(Float32, 10)
+    @inferred gausslobatto(BigFloat, 10)
+
     n = 2
     x, w = gausslobatto(n)
     @test x[1] ≈ -1.0


### PR DESCRIPTION
This continues #149 to support arbitrary types for the remaining rules.

cc @oscardssmith, @ranocha

For some parts I used the help of AI tools, but I supervised the AI and reviewed and edited the implementation myself.