### PR TITLE
Fix `gaussjacobi` with `n > 100` and non-`Float64`

### DIFF
--- a/src/gaussjacobi.jl
+++ b/src/gaussjacobi.jl
@@ -43,7 +43,7 @@ function gaussjacobi(n::Integer, α::Real, β::Real)
         return [(β - α) / (α + β + 2)], [2^(α + β + 1) * beta(α + 1, β + 1)]
     elseif min(α, β) ≤ -1.0
         return throw(DomainError((α, β), "The Jacobi parameters correspond to a nonintegrable weight function"))
-    elseif (n ≤ 100 || T !== Float64) && max(α, β) < 5.0
+    elseif (n ≤ 100 || (T <: AbstractFloat && T !== Float64)) && max(α, β) < 5.0
         return jacobi_rec(n, α, β)
     elseif n > 100 && max(α, β) < 5.0
         return jacobi_asy(n, α, β)

--- a/src/gaussjacobi.jl
+++ b/src/gaussjacobi.jl
@@ -43,7 +43,7 @@ function gaussjacobi(n::Integer, α::Real, β::Real)
         return [(β - α) / (α + β + 2)], [2^(α + β + 1) * beta(α + 1, β + 1)]
     elseif min(α, β) ≤ -1.0
         return throw(DomainError((α, β), "The Jacobi parameters correspond to a nonintegrable weight function"))
-    elseif n ≤ 100 && max(α, β) < 5.0
+    elseif (n ≤ 100 || T !== Float64) && max(α, β) < 5.0
         return jacobi_rec(n, α, β)
     elseif n > 100 && max(α, β) < 5.0
         return jacobi_asy(n, α, β)

--- a/test/test_gaussjacobi.jl
+++ b/test/test_gaussjacobi.jl
@@ -231,6 +231,12 @@
         @test abs(w[3] - big(2482452398859023537636458227096017466104571146686194593251519240011574719667464) / big(10)^79) < 1.0e-70
     end
 
+    @testset "Float32 parameters with n > 100" begin
+        x, w = gaussjacobi(160, Float32(1), Float32(1))
+        @test eltype(x) == Float32
+        @test eltype(w) == Float32
+    end
+
     @testset "boundary asymptotics were previously not implemented (#58,#130)" begin
         # check example from issue #58
         _, w = gaussjacobi(2^10, 0.25, 0)


### PR DESCRIPTION
Since, `jacobi_asy` is only defined for `Float64`, we need to guard against trying to call it with non-`Float64` values for `α` and `β` similar to https://github.com/JuliaApproximation/FastGaussQuadrature.jl/blob/c71525733a6739655e4f2927f0b3f254c724dbd8/src/gausslegendre.jl#L61
On master:
```julia
julia> x, w = gaussjacobi(101, Float32(1), Float32(1))
Warning: detected a stack overflow; program state may be corrupted, so further execution might be unreliable.
ERROR: StackOverflowError:
Stacktrace:
 [1] jacobi_asy(n::Int64, α::Float32, β::Float32) (repeats 79984 times)
   @ FastGaussQuadrature ~/.julia/dev/FastGaussQuadrature/src/gaussjacobi.jl:59
```

Fixes #133.